### PR TITLE
chore(deployer): retry + reduce chunk_size/max_chunk_bytes

### DIFF
--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -93,6 +93,8 @@ def index(
         for success, info in streaming_bulk(
             connection,
             generator(),
+            max_chunk_bytes=52428800, # default: 104857600
+            max_retries=4, # default: 0
             # If the bulk indexing failed, it will by default raise a BulkIndexError.
             # Setting this to 'False' will suppress that.
             raise_on_exception=False,

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -93,8 +93,8 @@ def index(
         for success, info in streaming_bulk(
             connection,
             generator(),
-            max_chunk_bytes=52428800, # default: 104857600
-            max_retries=4, # default: 0
+            max_chunk_bytes=52428800,  # default: 104857600
+            max_retries=4,  # default: 0
             # If the bulk indexing failed, it will by default raise a BulkIndexError.
             # Setting this to 'False' will suppress that.
             raise_on_exception=False,

--- a/deployer/src/deployer/search/__init__.py
+++ b/deployer/src/deployer/search/__init__.py
@@ -93,6 +93,7 @@ def index(
         for success, info in streaming_bulk(
             connection,
             generator(),
+            chunk_size=250,  # default: 500
             max_chunk_bytes=52428800,  # default: 104857600
             max_retries=4,  # default: 0
             # If the bulk indexing failed, it will by default raise a BulkIndexError.


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Retry Elasticsearch indexing, and reduce request size by reducing chunk size (number of items in a chunk) and max request size.

### Motivation

Stage build regularly fails during search index with the following error message:

```
elasticsearch.exceptions.TransportError: TransportError(429, 'circuit_breaking_exception', '[parent] Data too large, data for [<http_request>] would be [1032261768/984.4mb], which is larger than the limit of [1020054732/972.7mb], real usage: [1032261768/984.4mb], new bytes reserved: [0/0b], usages [request=0/0b, fielddata=0/0b, in_flight_requests=0/0b, model_inference=0/0b, eql_sequence=0/0b, accounting=975128/952.2kb]')
```

### Additional details

Workflow run with this change: https://github.com/mdn/dex/actions/runs/18172146864

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
