### PR TITLE
ci(test-build): cleanup rari build

### DIFF
--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -222,6 +222,7 @@ jobs:
           cd mdn/rari
           cargo build --release
           cp target/release/rari ../fred/node_modules/@mdn/rari/bin/
+          rm -rf target
 
       - name: Print information about CPU
         run: cat /proc/cpuinfo


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Clean up rari build after copying binary in `test-build` workflow.

### Motivation

Test build with `rari-ref` fails with `System.IO.IOException: No space left on device`.

### Additional details

Workflow ran succesfully with this change: https://github.com/mdn/dex/actions/runs/18172474547

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
