### PR TITLE
chore(lefthook): remove obsolete rari postinstall

### DIFF
--- a/.lefthook.yml
+++ b/.lefthook.yml
@@ -39,8 +39,6 @@ post-merge:
   commands:
     yarn-install:
       run: yarn install --ignore-scripts
-    rari-postinstall:
-      run: npm run postinstall --prefix node_modules/@mdn/rari
 
 output:
   - summary


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes the obsolete rari postinstall command from the post-merge hook.

### Motivation

Rari was a yari dependency, and it is no longer a dex dependency.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Extracted from https://github.com/mdn/dex/pull/31.
