### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/pr-deployer.yml
+++ b/.github/workflows/pr-deployer.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install Python
         id: setup-python

--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           path: mdn/dex
+          persist-credentials: false
 
       - name: Checkout (content)
         uses: actions/checkout@v5
@@ -83,6 +84,7 @@ jobs:
           # but for now it's good enough. We'll need all the history
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout (blog)
         uses: actions/checkout@v5
@@ -92,6 +94,7 @@ jobs:
           path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
+          persist-credentials: false
 
       - name: Checkout (generic-content)
         uses: actions/checkout@v5
@@ -99,6 +102,7 @@ jobs:
         with:
           repository: mdn/generic-content
           path: mdn/generic-content
+          persist-credentials: false
 
       - name: Checkout (curriculum)
         uses: actions/checkout@v5
@@ -106,6 +110,7 @@ jobs:
         with:
           repository: mdn/curriculum
           path: mdn/curriculum
+          persist-credentials: false
 
       # Our usecase is a bit complicated. When the cron schedule runs this workflow,
       # we rely on the env vars defined at the top of the file. But if it's a manual
@@ -130,6 +135,7 @@ jobs:
           path: mdn/translated-content
           # See matching warning for mdn/content checkout step
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout (translated-content-de)
         uses: actions/checkout@v5
@@ -137,6 +143,7 @@ jobs:
         with:
           repository: mdn/translated-content-de
           path: mdn/translated-content-de
+          persist-credentials: false
 
       - name: Move de into translated-content
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
@@ -157,6 +164,7 @@ jobs:
         with:
           repository: mdn/mdn-contributor-spotlight
           path: mdn/mdn-contributor-spotlight
+          persist-credentials: false
 
       - uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -36,6 +36,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -97,6 +97,7 @@ jobs:
         with:
           fetch-depth: 0
           path: mdn/dex
+          persist-credentials: false
 
       - name: Merge main
         working-directory: mdn/dex
@@ -121,6 +122,7 @@ jobs:
           # but for now it's good enough. We'll need all the history
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout (blog)
         uses: actions/checkout@v5
@@ -130,6 +132,7 @@ jobs:
           path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
+          persist-credentials: false
 
       - name: Checkout (generic-content)
         uses: actions/checkout@v5
@@ -137,6 +140,7 @@ jobs:
         with:
           repository: mdn/generic-content
           path: mdn/generic-content
+          persist-credentials: false
 
       - name: Checkout (curriculum)
         uses: actions/checkout@v5
@@ -144,6 +148,7 @@ jobs:
         with:
           repository: mdn/curriculum
           path: mdn/curriculum
+          persist-credentials: false
 
       - name: Checkout (translated-content)
         uses: actions/checkout@v5
@@ -153,6 +158,7 @@ jobs:
           path: mdn/translated-content
           # See matching warning for mdn/content checkout step
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Checkout (translated-content-de)
         uses: actions/checkout@v5
@@ -160,6 +166,7 @@ jobs:
         with:
           repository: mdn/translated-content-de
           path: mdn/translated-content-de
+          persist-credentials: false
 
       - name: Move de into translated-content
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
@@ -180,6 +187,7 @@ jobs:
         with:
           repository: mdn/mdn-contributor-spotlight
           path: mdn/mdn-contributor-spotlight
+          persist-credentials: false
 
       - uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -90,6 +90,7 @@ jobs:
         with:
           fetch-depth: 0
           path: mdn/dex
+          persist-credentials: false
 
       - name: Merge main (if possible)
         working-directory: mdn/dex
@@ -115,6 +116,7 @@ jobs:
           # so we can figure out each document's last-modified date.
           fetch-depth: 0
           ref: ${{ github.event.inputs.content-ref }}
+          persist-credentials: false
 
       - name: Checkout (blog)
         uses: actions/checkout@v5
@@ -124,6 +126,7 @@ jobs:
           path: mdn/blog
           lfs: true
           token: ${{ secrets.MDN_STUDIO_PAT }}
+          persist-credentials: false
 
       - name: Checkout (generic-content)
         uses: actions/checkout@v5
@@ -131,6 +134,7 @@ jobs:
         with:
           repository: mdn/generic-content
           path: mdn/generic-content
+          persist-credentials: false
 
       - name: Checkout (curriculum)
         uses: actions/checkout@v5
@@ -138,6 +142,7 @@ jobs:
         with:
           repository: mdn/curriculum
           path: mdn/curriculum
+          persist-credentials: false
 
       - name: Checkout (translated-content)
         uses: actions/checkout@v5
@@ -148,6 +153,7 @@ jobs:
           # See matching warning for mdn/content checkout step
           fetch-depth: 0
           ref: ${{ github.event.inputs.translated-content-ref }}
+          persist-credentials: false
 
       - name: Checkout (translated-content-de)
         uses: actions/checkout@v5
@@ -155,6 +161,7 @@ jobs:
         with:
           repository: mdn/translated-content-de
           path: mdn/translated-content-de
+          persist-credentials: false
 
       - name: Move de into translated-content
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}
@@ -175,6 +182,7 @@ jobs:
         with:
           repository: mdn/mdn-contributor-spotlight
           path: mdn/mdn-contributor-spotlight
+          persist-credentials: false
 
       - uses: actions/checkout@v5
         if: ${{ ! vars.SKIP_BUILD }}
@@ -204,6 +212,7 @@ jobs:
           repository: mdn/rari
           path: mdn/rari
           ref: ${{ github.event.inputs.rari-ref }}
+          persist-credentials: false
 
       - name: Cache Cargo registry
         if: ${{ !( vars.SKIP_BUILD || github.event.inputs.rari-ref == '' ) }}

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description
  
Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
