### PR TITLE
ci(dependabot): update GitHub Actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    commit-message:
+      prefix: "ci(deps): "
 
   - package-ecosystem: "pip"
     directory: "/deployer"


### PR DESCRIPTION
### Description

Adds or updates the Dependabot config for GitHub Actions:

```yaml
  - package-ecosystem: "github-actions"
    directory: "/"
    schedule:
      interval: "weekly"
    commit-message:
      prefix: "ci(deps): "
```

### Motivation

Ensures used GitHub Action dependencies are updated consistently and regularly (but not daily) across our repos.

### Additional details

See also: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/887.