### PR TITLE
ci(workflows): disable `actions/checkout` credential persistance

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -171,6 +171,7 @@ jobs:
         with:
           repository: mdn/fred
           path: mdn/fred
+          persist-credentials: false
 
       - name: Setup Node.js environment
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -194,6 +194,7 @@ jobs:
         with:
           repository: mdn/fred
           path: mdn/fred
+          persist-credentials: false
 
       - name: Setup Node.js environment
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -190,6 +190,7 @@ jobs:
           repository: mdn/fred
           path: mdn/fred
           ref: ${{ github.event.inputs.fred-ref }}
+          persist-credentials: false
 
       - name: Setup Node.js environment
         if: ${{ ! vars.SKIP_BUILD || ! vars.SKIP_FUNCTION }}


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds `persist-credentials: false` to all `actions/checkout` workflow steps.

## Motivation

Applies security best practices. It prevents persistance of the `GITHUB_TOKEN` in the local git config.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/883.
