### PR TITLE
ci(workflows): disable automatic setup-node caching

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -178,6 +178,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: mdn/fred/.nvmrc
+          package-manager-cache: false
 
       - name: Install all fred packages
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/review-deploy.yml
+++ b/.github/workflows/review-deploy.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: ".nvmrc"
+          package-manager-cache: false
 
       - name: Prepare Cloud Function
         working-directory: cloud-function

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -201,6 +201,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: mdn/fred/.nvmrc
+          package-manager-cache: false
 
       - name: Install all fred packages
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -197,6 +197,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: mdn/fred/.nvmrc
+          package-manager-cache: false
 
       - name: Install all fred packages
         if: ${{ ! vars.SKIP_BUILD }}


### PR DESCRIPTION
### Description

Sets `package-manager-cache: false` to all `actions/setup-node` workflow steps that don't already have caching configured via either `package-manager-cache` or `cache`.

### Motivation

The new default behavior introduced in [`actions/setup-node v5.0.0`](https://github.com/actions/setup-node/releases/tag/v5.0.0) is not safe.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
