### PR TITLE
chore(deps-dev): remove eslint-plugin-wc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "eslint-plugin-jest": "^29.0.1",
         "eslint-plugin-n": "^17.21.0",
         "eslint-plugin-unicorn": "^56.0.1",
-        "eslint-plugin-wc": "^2.2.1",
         "jest": "^29.7.0",
         "jest-resolve": "^30.1.3",
         "lefthook": "^1.12.4",
@@ -11111,20 +11110,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-plugin-wc": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-wc/-/eslint-plugin-wc-2.2.1.tgz",
-      "integrity": "sha512-KstLqGmyQz088DvFlDYHg0sHih+w2QeulreCi1D1ftr357klO2zqHdG/bbnNMmuQdVFDuNkopNIyNhmG0XCT/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-valid-element-name": "^1.0.0",
-        "js-levenshtein-esm": "^1.2.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=8.40.0"
-      }
-    },
     "node_modules/eslint-scope": {
       "version": "7.2.2",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
@@ -13032,13 +13017,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-potential-custom-element-name": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
-      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -13192,16 +13170,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-valid-element-name": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-valid-element-name/-/is-valid-element-name-1.0.0.tgz",
-      "integrity": "sha512-GZITEJY2LkSjQfaIPBha7eyZv+ge0PhBR7KITeCCWvy7VBQrCUdFkvpI+HrAPQjVtVjy1LvlEkqQTHckoszruw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "is-potential-custom-element-name": "^1.0.0"
       }
     },
     "node_modules/is-weakmap": {
@@ -14234,13 +14202,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/js-levenshtein-esm": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/js-levenshtein-esm/-/js-levenshtein-esm-1.2.0.tgz",
-      "integrity": "sha512-fzreKVq1eD7eGcQr7MtRpQH94f8gIfhdrc7yeih38xh684TNMK9v5aAu2wxfIRMk/GpAJRrzcirMAPIaSDaByQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "eslint-plugin-jest": "^29.0.1",
     "eslint-plugin-n": "^17.21.0",
     "eslint-plugin-unicorn": "^56.0.1",
-    "eslint-plugin-wc": "^2.2.1",
     "jest": "^29.7.0",
     "jest-resolve": "^30.1.3",
     "lefthook": "^1.12.4",


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes `eslint-plugin-wc` from our devDependencies.

### Motivation

This ESLint plugin is used to lint Web Components, and Dex doesn't contain any.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
