### PR TITLE
fix(cloud-function): add foreman dependency necessary for running npm start

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -32,6 +32,7 @@
         "@types/http-proxy": "^1.17.16",
         "@types/http-server": "^0.12.4",
         "cross-env": "^7.0.3",
+        "foreman": "^3.0.1",
         "http-proxy": "^1.18.1",
         "http-server": "^14.1.1",
         "nodemon": "^3.1.10",
@@ -50,9 +51,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@adzerk/decision-sdk": {
-      "version": "1.0.0-beta.27",
-      "resolved": "https://registry.npmjs.org/@adzerk/decision-sdk/-/decision-sdk-1.0.0-beta.27.tgz",
-      "integrity": "sha512-KnTDmUiKZL+pEPCd7Nkfi+bMhRHjjWh4X3WWc4yKWkh3Sd19FyVDdCdwRUQUpKsv548bmJp2OxQyqV4hLG/0BQ==",
+      "version": "1.0.0-beta.28",
+      "resolved": "https://registry.npmjs.org/@adzerk/decision-sdk/-/decision-sdk-1.0.0-beta.28.tgz",
+      "integrity": "sha512-zRoJK+JeykialMPa3PxwZogKhP4NSgQoQV/nisj2eWnBf5XhKNo+tn1bMTBFAwCw23Ayyi+7eo5WfFyXWipisg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@adzerk/api-decision-js": "^1.0.10",
@@ -1838,6 +1839,13 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2483,6 +2491,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/foreman": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/foreman/-/foreman-3.0.1.tgz",
+      "integrity": "sha512-ek/qoM0vVKpxzkBUQN9k4Fs7l0XsHv4bqxuEW6oqIS4s0ouYKsQ19YjBzUJKTFRumFiSpUv7jySkrI6lfbhjlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.15.1",
+        "http-proxy": "^1.17.0",
+        "mustache": "^2.2.1",
+        "shell-quote": "^1.6.1"
+      },
+      "bin": {
+        "nf": "nf.js"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/form-data": {
@@ -3594,6 +3621,19 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/mustache": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-2.3.2.tgz",
+      "integrity": "sha512-KpMNwdQsYz3O/SBS1qJ/o3sqUJ5wSb8gb0pul8CO0S56b9Y2ALm8zCfsjPXsqGFfoNBkDwZuZIAjhsZI03gYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      },
+      "engines": {
+        "npm": ">=1.4.0"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -5495,7 +5535,7 @@
       "version": "0.0.1",
       "license": "MPL-2.0",
       "dependencies": {
-        "@adzerk/decision-sdk": "^1.0.0-beta.27",
+        "@adzerk/decision-sdk": "^1.0.0-beta.28",
         "he": "^1.2.0"
       }
     },

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -50,6 +50,7 @@
     "@types/http-proxy": "^1.17.16",
     "@types/http-server": "^0.12.4",
     "cross-env": "^7.0.3",
+    "foreman": "^3.0.1",
     "http-proxy": "^1.18.1",
     "http-server": "^14.1.1",
     "nodemon": "^3.1.10",


### PR DESCRIPTION
## Before

```
npm start  

> mdn-function@0.0.1 start
> nf start

sh: line 1: nf: command not found
```

## After

```
npm start

> mdn-function@0.0.1 start
> nf start

(node:254566) [DEP0060] DeprecationWarning: The `util._extend` API is deprecated. Please use Object.assign() instead.
(Use `node --trace-deprecation ...` to show where the warning was created)
5:36:09 PM server.1 |  > mdn-function@0.0.1 server:watch
5:36:09 PM server.1 |  > nodemon --exec npm run server
...
```