### PR TITLE
ci(auto-merge): approve in addition to comment

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -24,4 +24,6 @@ jobs:
         if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' }}
         env:
           GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
-        run: gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"
+        run: |
+          gh pr review ${{ github.event.pull_request.html_url }} --approve 
+          gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `auto-merge` workflow to approve the PR in addition to commenting `@dependabot squash and merge`.

### Motivation

This repo now requires at least one approval to merge PRs, and this blocks Dependabot PRs from being merged automatically.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Same as:

- https://github.com/mdn/fred/pull/762
- https://github.com/mdn/triagebot/pull/127