### PR TITLE
chore(csp): relax GA4 script-src

### DIFF
--- a/libs/constants/index.js
+++ b/libs/constants/index.js
@@ -67,7 +67,7 @@ export const CSP_SCRIPT_SRC_VALUES = [
 
   // GA4.
   "https://www.google-analytics.com/analytics.js",
-  "https://www.googletagmanager.com/gtag/js",
+  "https://*.googletagmanager.com",
 
   "assets.codepen.io",
   "production-assets.codepen.io",


### PR DESCRIPTION
### Description

Relaxes the Content-Security-Policy w.r.t. the Google Tag Manager origin.

### Motivation

- Applies the `script-src` recommended by https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics.
- Avoids blocking the `/debug` path.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/877.