### PR TITLE
ci(build): separate rari + fred build steps

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -224,7 +224,6 @@ jobs:
         working-directory: mdn/fred
         env:
           DEX_ROOT: ${{ github.workspace }}/mdn/dex
-          BASE_URL: "https://developer.mozilla.org"
           BUILD_OUT_ROOT: "out"
 
           # This is the Google Analytics measurement ID for:

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -247,7 +247,6 @@ jobs:
         working-directory: mdn/fred
         env:
           DEX_ROOT: ${{ github.workspace }}/mdn/dex
-          BASE_URL: "https://developer.allizom.org"
           BUILD_OUT_ROOT: "out"
 
           FRED_ROBOTS_GLOBAL_ALLOW: false

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -280,7 +280,6 @@ jobs:
         working-directory: mdn/fred
         env:
           DEX_ROOT: ${{ github.workspace }}/mdn/dex
-          BASE_URL: "https://test.developer.allizom.org"
           BUILD_OUT_ROOT: "out"
 
           FRED_ROBOTS_GLOBAL_ALLOW: false


### PR DESCRIPTION
### Description

Refactors the build workflows, separating the rari and fred build parts into two separate steps.

### Motivation

Helps identifying the respective build time, and separates the environment variables.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
