### PR TITLE
ci(build): build with large runner

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   build:
     environment: prod
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-dex-builder
 
     # Only run the scheduled workflows on the main repo.
     if: github.repository == 'mdn/dex'

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -50,7 +50,7 @@ jobs:
 
   build:
     environment: stage
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-dex-builder
 
     # We only ever want to deploy the `next` branch to stage.
     if: ${{ github.repository == 'mdn/dex' && github.ref_name == 'next' }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -65,7 +65,7 @@ jobs:
 
   build:
     environment: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-dex-builder
 
     # When run from `main` branch, only trigger workflow on `test` branch (see above).
     if: github.repository == 'mdn/dex' && github.ref_name != 'main'


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Deploy prod/stage/test on [GitHub large runner](https://docs.github.com/en/actions/how-tos/manage-runners/larger-runners).

### Motivation

Our deployments [started failing on Saturday](https://github.com/mdn/dex/actions/runs/19350193756) (2025-11-15) with "No space left on device" errors.

The GitHub standard runner for `ubuntu-latest` [only has 14 GB of storage](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories), whereas the equivalent 4-core large runner [has 150 GB of storage](https://docs.github.com/en/actions/reference/runners/larger-runners#specifications-for-general-larger-runners).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
