### PR TITLE
docs(SECURITY): sync security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,4 +11,3 @@ package.json @mdn/engineering @mdn-bot
 package-lock.json @mdn/engineering @mdn-bot
 poetry.lock @mdn/engineering @mdn-bot
 pyproject.toml @mdn/engineering @mdn-bot
-/SECURITY.md @mdn/engineering


### PR DESCRIPTION
### Description

Syncs the `SECURITY.md` file with the [canonical version from mdn/fred](https://github.com/mdn/fred/blob/main/SECURITY.md).

### Motivation

Ensures consistent security reporting procedures across all MDN repositories.

### Additional details

See: https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1068.