### PR TITLE
ci(stage-build,test-build): don't pull deploy branch

### DIFF
--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -69,7 +69,6 @@ jobs:
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
           git status
-          git pull
           git checkout main
           git status
           git checkout -

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -98,7 +98,6 @@ jobs:
           git config --global user.email "108879845+mdn-bot@users.noreply.github.com"
           git config --global user.name "mdn-bot"
           git status
-          git pull
           git checkout main
           git status
           git checkout -


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `stage-build` and `test-build` workflow to no longer run `git pull` before merging `main`.

### Motivation

The `git pull` only had an effect if new commits were pushed to the branch since the build was kicked off. It isn't necessary to take these commits into consideration, and it fails the build if the deployed branch got force-pushed (including on re-run).

### Additional details

Error message in [this failed run](https://github.com/mdn/dex/actions/runs/19433333228/job/55597584947) was:

```
On branch split-rari-and-fred-build
Your branch is up to date with 'origin/split-rari-and-fred-build'.

nothing to commit, working tree clean
From https://github.com/mdn/dex
 + 45ffcef...fd2945c split-rari-and-fred-build -> origin/split-rari-and-fred-build  (forced update)
hint: You have divergent branches and need to specify how to reconcile them.
hint: You can do so by running one of the following commands sometime before
hint: your next pull:
hint:
hint:   git config pull.rebase false  # merge
hint:   git config pull.rebase true   # rebase
hint:   git config pull.ff only       # fast-forward only
hint:
hint: You can replace "git config" with "git config --global" to set a default
hint: preference for all repositories. You can also pass --rebase, --no-rebase,
hint: or --ff-only on the command line to override the configured default per
hint: invocation.
fatal: Need to specify how to reconcile divergent branches.
```

### Related issues and pull requests

Noticed in https://github.com/mdn/dex/pull/127.