### PR TITLE
ci(build): remove INTERACTIVE_EXAMPLES_BASE_URL env

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -201,7 +201,6 @@ jobs:
           BASE_URL: "https://developer.mozilla.org"
           BUILD_OUT_ROOT: "out"
           LIVE_SAMPLES_BASE_URL: https://live.mdnplay.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.mozilla.net
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
 
           # Sentry.

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -223,7 +223,6 @@ jobs:
           BASE_URL: "https://developer.allizom.org"
           BUILD_OUT_ROOT: "out"
           LIVE_SAMPLES_BASE_URL: https://live.mdnyalp.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
 
           # Sentry.

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -261,7 +261,6 @@ jobs:
           BASE_URL: "https://test.developer.allizom.org"
           BUILD_OUT_ROOT: "out"
           LIVE_SAMPLES_BASE_URL: https://live.test.mdnyalp.dev
-          INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
           ADDITIONAL_LOCALES_FOR_GENERICS_AND_SPAS: de
 
           # Increase GitHub API rate limit.
@@ -289,9 +288,6 @@ jobs:
 
           # This adds the ability to sign in (stage only for now)
           REACT_APP_DISABLE_AUTH: false
-
-          # Use the stage version of interactive examples in react app
-          REACT_APP_INTERACTIVE_EXAMPLES_BASE_URL: https://interactive-examples.mdn.allizom.net
 
           # Offline updates
           REACT_APP_UPDATES_BASE_URL: https://updates.developer.allizom.org


### PR DESCRIPTION

<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the build workflows, removing the obsolete `INTERACTIVE_EXAMPLES_BASE_URL` environment variable.

### Motivation

It was only used for the `EmbedInteractiveExample` macro, and interactive examples were inlined into content.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/616.