### PR TITLE
chore(deps): bump npm from 11.6.2 to 11.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.53.0"
   },
-  "packageManager": "npm@11.6.2",
+  "packageManager": "npm@11.7.0",
   "engines": {
     "node": ">=24"
   }


### PR DESCRIPTION
### Description

Updates the `packageManager` field in `package.json` from `npm@11.6.2` to `npm@11.7.0`.

### Motivation

Ensures repositories use the latest npm version.

### Additional details

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1205.