### PR TITLE
feat(cloud-function): cache redirects for 1h by default

### DIFF
--- a/cloud-function/src/utils.js
+++ b/cloud-function/src/utils.js
@@ -28,13 +28,13 @@ export function getRequestCountry(req) {
  * @param {string} location - Redirect location URL
  * @param {object} options - Redirect options
  * @param {number} [options.status=302] - HTTP status code
- * @param {number} [options.cacheControlSeconds=0] - Cache duration in seconds
+ * @param {number} [options.cacheControlSeconds=3600] - Cache duration in seconds
  * @returns {void}
  */
 export function redirect(
   res,
   location,
-  { status = 302, cacheControlSeconds = 0 } = {}
+  { status = 302, cacheControlSeconds = 3600 } = {}
 ) {
   let cacheControlValue;
   if (cacheControlSeconds) {


### PR DESCRIPTION
### Description

Updates the `redirect()` helper in the Cloud Function, caching redirects for 1 hour by default.

### Motivation

Improve performance, reduce load on Cloud Function.

### Additional details

Previously, we defaulted to `no-store` for the following redirects:

1. Locale redirects for URLs without locale.
2. Preferred locale redirects.

All other redirects already pass `cacheControlSeconds: THIRTY_DAYS` explicitly, and are unaffected by this change.

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
