### PR TITLE
ci(build): add FRED_TRANSCEND_AIRGAP_URL

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -268,6 +268,7 @@ jobs:
           FRED_GLEAN_ENABLED: true
 
           # Transcend Consent Management
+          FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
           FRED_TRANSCEND_BUNDLE_ID: ${{ secrets.TRANSCEND_BUNDLE_ID }}
 
           # Newsletter

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -288,6 +288,7 @@ jobs:
           FRED_GLEAN_ENABLED: true
 
           # Transcend Consent Management
+          FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm-test/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
           FRED_TRANSCEND_BUNDLE_ID: ${{ secrets.TRANSCEND_BUNDLE_ID }}
 
           # Newsletter


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Updates the `stage-build` and `prod-build`, setting `FRED_TRANSCEND_AIRGAP_URL`.

### Motivation

Use test bundle for stage, and production bundle only for production.

### Additional details

Blocks https://github.com/mdn/fred/pull/1497.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1422.

Follow-up of https://github.com/mdn/dex/pull/275.