### PR TITLE
fix(cloud-function): respect `Accept-Language: zh-TW`

### DIFF
--- a/cloud-function/src/internal/locale-utils/index.js
+++ b/cloud-function/src/internal/locale-utils/index.js
@@ -102,9 +102,13 @@ export function getLocale(
 
   // Each header in request.headers is always a list of objects.
   const value = getAcceptLanguage(request);
+  // Try a strict match first so that e.g. `zh-TW` resolves to `zh-TW`
+  // rather than the first `zh-*` entry in the supported list. Fall back to
+  // a loose match so that e.g. `en-GB` still resolves to `en-US`.
   const locale =
     value &&
-    acceptLanguageParser.pick(validLocalesList, value, { loose: true });
+    (acceptLanguageParser.pick(validLocalesList, value) ||
+      acceptLanguageParser.pick(validLocalesList, value, { loose: true }));
   return locale || fallback;
 }
 

--- a/cloud-function/src/internal/locale-utils/index.test.js
+++ b/cloud-function/src/internal/locale-utils/index.test.js
@@ -1,0 +1,163 @@
+/** @import { Request } from "express" */
+
+import { describe, it } from "node:test";
+import { strictEqual } from "node:assert/strict";
+
+import { getLocale, isValidLocale } from "./index.js";
+
+/**
+ * @param {{ acceptLanguage?: string, cookie?: string }} [headers]
+ * @returns {Request}
+ */
+function makeRequest({ acceptLanguage, cookie } = {}) {
+  /** @type {Record<string, string>} */
+  const headers = {};
+  if (acceptLanguage !== undefined) {
+    headers["accept-language"] = acceptLanguage;
+  }
+  if (cookie !== undefined) {
+    headers["cookie"] = cookie;
+  }
+  return /** @type {Request} */ (/** @type {unknown} */ ({ headers }));
+}
+
+describe("getLocale", () => {
+  describe("Accept-Language", () => {
+    it("returns the exact regional match for zh-TW", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "zh-TW" }), {}),
+        "zh-TW"
+      );
+    });
+
+    it("returns the exact regional match for zh-CN", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "zh-CN" }), {}),
+        "zh-CN"
+      );
+    });
+
+    it("returns the exact regional match for pt-BR", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "pt-BR" }), {}),
+        "pt-BR"
+      );
+    });
+
+    it("matches a bare language code to a supported region (en -> en-US)", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "en" }), {}),
+        "en-US"
+      );
+    });
+
+    it("matches a bare language code to a supported region (pt -> pt-BR)", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "pt" }), {}),
+        "pt-BR"
+      );
+    });
+
+    it("falls back loosely when the region is unsupported (en-GB -> en-US)", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "en-GB" }), {}),
+        "en-US"
+      );
+    });
+
+    it("falls back loosely when the region is unsupported (pt-PT -> pt-BR)", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "pt-PT" }), {}),
+        "pt-BR"
+      );
+    });
+
+    it("respects quality values to pick zh-TW over zh-CN", () => {
+      strictEqual(
+        getLocale(
+          makeRequest({ acceptLanguage: "zh-CN;q=0.5,zh-TW;q=0.9" }),
+          {}
+        ),
+        "zh-TW"
+      );
+    });
+
+    it("returns the configured fallback when no header is present", () => {
+      strictEqual(getLocale(makeRequest(), { fallback: "fr" }), "fr");
+    });
+
+    it("returns en-US when no header is present and no fallback is given", () => {
+      strictEqual(getLocale(makeRequest(), {}), "en-US");
+    });
+
+    it("returns the configured fallback when no language is supported", () => {
+      strictEqual(
+        getLocale(makeRequest({ acceptLanguage: "xx-YY" }), {
+          fallback: "fr",
+        }),
+        "fr"
+      );
+    });
+  });
+
+  describe("preferredlocale cookie", () => {
+    it("returns the cookie locale when valid", () => {
+      strictEqual(
+        getLocale(makeRequest({ cookie: "preferredlocale=zh-TW" }), {}),
+        "zh-TW"
+      );
+    });
+
+    it("normalises cookie casing to the canonical form", () => {
+      strictEqual(
+        getLocale(makeRequest({ cookie: "preferredlocale=zh-tw" }), {}),
+        "zh-TW"
+      );
+    });
+
+    it("prefers the cookie over Accept-Language", () => {
+      strictEqual(
+        getLocale(
+          makeRequest({
+            acceptLanguage: "en-US",
+            cookie: "preferredlocale=zh-TW",
+          }),
+          {}
+        ),
+        "zh-TW"
+      );
+    });
+
+    it("falls back to Accept-Language when the cookie is invalid", () => {
+      strictEqual(
+        getLocale(
+          makeRequest({
+            acceptLanguage: "fr",
+            cookie: "preferredlocale=xx-YY",
+          }),
+          {}
+        ),
+        "fr"
+      );
+    });
+  });
+});
+
+describe("isValidLocale", () => {
+  it("accepts a canonical locale", () => {
+    strictEqual(isValidLocale("zh-TW"), true);
+  });
+
+  it("accepts a lowercase locale", () => {
+    strictEqual(isValidLocale("zh-tw"), true);
+  });
+
+  it("rejects a retired locale", () => {
+    strictEqual(isValidLocale("it"), false);
+  });
+
+  it("rejects a non-string", () => {
+    strictEqual(isValidLocale(null), false);
+    strictEqual(isValidLocale(42), false);
+  });
+});


### PR DESCRIPTION
### Description

Updates the locale redirect to honor `Accept-Language: zh-TW`, by trying a strict language pick first, before falling back to a loose language pick.

### Motivation

Fix content negotiation bug where this caused a redirect to `zh-CN`.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/dex/issues/321.