### PR TITLE
fix(cloud-function): remove npm requirement

### DIFF
--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -55,11 +55,5 @@
   "packageManager": "npm@11.12.1",
   "engines": {
     "node": ">=24"
-  },
-  "devEngines": {
-    "packageManager": {
-      "name": "npm",
-      "version": ">=11.8.0"
-    }
   }
 }


### PR DESCRIPTION
### Description

Removes the npm version constraint for `/cloud-function`.

### Motivation

Google Cloud Run still runs 24.13.0, which comes with npm 11.6.2, so we cannot require npm 11.8.0 yet, as it causes `npm install` to fail.

### Additional details

Verified by deploying the review environment with this commit: https://github.com/mdn/dex/actions/runs/25311341122/job/74198715749

### Related issues and pull requests

Partially reverts 06f413cf2bfbf7eaa906a36a5b07d9ad9d0ce82a.