### PR TITLE
ci(build): run rari build with --issues --issues-per-locale

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -216,7 +216,7 @@ jobs:
           npm run rari content sync-translated-content
           npm run rari git-history
 
-          npm run rari build -- --all --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+          npm run rari build -- --all --issues --issues-per-locale --templ-stats
 
       - name: Build (fred)
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -238,7 +238,7 @@ jobs:
           npm run rari content sync-translated-content
           npm run rari git-history
 
-          npm run rari build -- --all --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+          npm run rari build -- --all --issues --issues-per-locale --templ-stats
 
       - name: Build (fred)
         if: ${{ ! vars.SKIP_BUILD }}

--- a/.github/workflows/test-build.yml
+++ b/.github/workflows/test-build.yml
@@ -271,7 +271,7 @@ jobs:
           npm run rari content sync-translated-content
           npm run rari git-history
 
-          npm run rari build -- --all --issues "$BUILD_OUT_ROOT/issues.json" --templ-stats
+          npm run rari build -- --all --issues --issues-per-locale --templ-stats
 
       - name: Build (fred)
         if: ${{ ! vars.SKIP_BUILD }}


### PR DESCRIPTION
### Description

Updates the build workflows to run rari builds with `--issues --issues-per-locale`:

- `--issues` parameter (path) is now optional.
- `--issues-per-locale` creates additional `issues.json` per locale.

### Motivation

Make it easier to identify and look at issues of a given locale.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/rari/pull/656.
