### PR TITLE
fix: pin npx tsc to the typescript package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "type": "module",
   "scripts": {
     "ai-help-macros": "node scripts/ai-help-macros.js",
-    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' ! -wholename '**/cloud-function/src/internal/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
+    "check:tsc": "find . -name 'tsconfig.json' ! -wholename '**/node_modules/**' ! -wholename '**/cloud-function/src/internal/**' -print0 | xargs -n1 -P 2 -0 sh -c 'cd `dirname $0` && echo \"🔄 $(pwd)\" && npx --package=typescript tsc --noEmit && echo \"☑️  $(pwd)\" || exit 255'",
     "eslint": "eslint .",
     "install:all": "find . -mindepth 2 -name 'package-lock.json' ! -wholename '**/node_modules/**' -print0 | xargs -n1 -0 sh -cx 'npm --prefix $(dirname $0) install'",
     "prepare": "npm run install:all",


### PR DESCRIPTION
### Description

- `package.json` (`check:tsc` script): `npx tsc --noEmit` → `npx --package=typescript tsc --noEmit`

### Motivation

Prevent a dependency-confusion fallback in `npx tsc`.

### Additional details

`tsc` is a bin of `typescript`. A standalone `tsc` package also exists on npm (a deprecated TypeScript-compiler release); if `typescript` isn't installed locally, `npx tsc` fetches that instead. Pinning `--package=typescript` (or calling the local bin) guarantees the intended compiler.

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/1680.