### PR TITLE
ci(build): disable Transcend integration

### DIFF
--- a/.github/workflows/prod-build.yml
+++ b/.github/workflows/prod-build.yml
@@ -245,9 +245,8 @@ jobs:
           FRED_GLEAN_CHANNEL: prod
           FRED_GLEAN_ENABLED: true
 
-          # Transcend Consent Management
-          FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
-          FRED_TRANSCEND_BUNDLE_ID: ${{ secrets.TRANSCEND_BUNDLE_ID }}
+          # Transcend Consent Management (disabled per https://github.com/mdn/fred/issues/1679)
+          # FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
 
           # Newsletter
           REACT_APP_NEWSLETTER_ENABLED: true

--- a/.github/workflows/stage-build.yml
+++ b/.github/workflows/stage-build.yml
@@ -265,9 +265,8 @@ jobs:
           FRED_GLEAN_CHANNEL: stage
           FRED_GLEAN_ENABLED: true
 
-          # Transcend Consent Management
-          FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm-test/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
-          FRED_TRANSCEND_BUNDLE_ID: ${{ secrets.TRANSCEND_BUNDLE_ID }}
+          # Transcend Consent Management (disabled per https://github.com/mdn/fred/issues/1679)
+          # FRED_TRANSCEND_AIRGAP_URL: https://transcend-cdn.com/cm-test/${{ secrets.TRANSCEND_BUNDLE_ID }}/airgap.js
 
           # Newsletter
           REACT_APP_NEWSLETTER_ENABLED: true


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Disables Transcend integration.

### Motivation

See: https://github.com/mdn/fred/issues/1679

> Until we have a decision around the future of cookie banners on MDN, there's no advantage in continuing to collect information with Transcend.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Fixes https://github.com/mdn/fred/issues/1679.
