### PR TITLE
chore(play): remove obsolete `DecompressionStream` eslint-disable

### DIFF
--- a/cloud-function/src/internal/play/index.js
+++ b/cloud-function/src/internal/play/index.js
@@ -616,7 +616,6 @@ export async function decompressFromBase64(base64String) {
   const hashArray = [...new Uint8Array(hashBuffer)].slice(0, 20);
   const hash = hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
 
-  // eslint-disable-next-line n/no-unsupported-features/node-builtins
   const decompressionStream = new DecompressionStream("deflate-raw");
 
   const decompressedStream = new Response(


### PR DESCRIPTION
### Description

Remove the inline `// eslint-disable-next-line n/no-unsupported-features/node-builtins` comment above the `DecompressionStream` usage in the Playground internal module.

### Motivation

Ensure the codebase stays free of unnecessary lint suppressions: the `n/no-unsupported-features/node-builtins` rule no longer flags `DecompressionStream`, so the disable comment is obsolete.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->