### PR TITLE
Revert "chore(deps): bump http-proxy-middleware from 3.0.5 to 4.1.1 in /cloud-function"

### DIFF
--- a/cloud-function/package-lock.json
+++ b/cloud-function/package-lock.json
@@ -18,7 +18,7 @@
         "dotenv": "^17.4.2",
         "express": "^5.2.1",
         "he": "^1.2.0",
-        "http-proxy-middleware": "^4.1.1",
+        "http-proxy-middleware": "^3.0.5",
         "sanitize-filename": "^1.6.4"
       },
       "devDependencies": {
@@ -463,7 +463,6 @@
       "version": "1.17.17",
       "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.17.tgz",
       "integrity": "sha512-ED6LB+Z1AVylNTu7hdzuBqOgMnvG/ld6wGCG8wFnAzKX5uyW2K3WD52v0gnLCTK/VLpXtKckgWuyScYK6cSPaw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -1499,7 +1498,6 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/express": {
@@ -1682,7 +1680,6 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
       "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -2070,7 +2067,6 @@
       "version": "1.18.1",
       "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
       "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.0",
@@ -2082,19 +2078,20 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-4.1.1.tgz",
-      "integrity": "sha512-KX5ZofGXLFXqFAkQoOWZ+rTtaLTut7m0gyL+QzJrdejtIZ+F4bPPDoe7reISg2+v0CAz5OfVwEJEhty7X+e57g==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.3",
-        "httpxy": "^0.5.3",
+        "@types/http-proxy": "^1.17.15",
+        "debug": "^4.3.6",
+        "http-proxy": "^1.18.1",
         "is-glob": "^4.0.3",
-        "is-plain-obj": "^4.1.0",
+        "is-plain-object": "^5.0.0",
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^22.15.0 || ^24.0.0 || >=26.0.0"
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-server": {
@@ -2124,12 +2121,6 @@
       "engines": {
         "node": ">=12"
       }
-    },
-    "node_modules/httpxy": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/httpxy/-/httpxy-0.5.3.tgz",
-      "integrity": "sha512-SMS9V6Sn7VWaS11lYhoAr0ceoaiolTWf4jYdJn0NJhCdKMu9R2H9Fh0LBDWBHQF6HRLI1PmaePYsjanSpE5PEw==",
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.7.2",
@@ -2475,16 +2466,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-promise": {
@@ -3785,7 +3773,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/resolve": {

--- a/cloud-function/package.json
+++ b/cloud-function/package.json
@@ -33,7 +33,7 @@
     "dotenv": "^17.4.2",
     "express": "^5.2.1",
     "he": "^1.2.0",
-    "http-proxy-middleware": "^4.1.1",
+    "http-proxy-middleware": "^3.0.5",
     "sanitize-filename": "^1.6.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts mdn/dex#380

Fixes https://github.com/mdn/dex/issues/419