### PR TITLE
fix(lowercase-pathname): assign path-relative `req.url`

### DIFF
--- a/cloud-function/src/middlewares/lowercase-pathname.js
+++ b/cloud-function/src/middlewares/lowercase-pathname.js
@@ -10,8 +10,8 @@
 export async function lowercasePathname(req, _res, next) {
   const urlParsed = new URL(req.url, `${req.protocol}://${req.headers.host}`);
   if (urlParsed.pathname) {
-    urlParsed.pathname = urlParsed.pathname.toLowerCase();
-    req.url = urlParsed.pathname + urlParsed.search + urlParsed.hash;
+    req.url =
+      urlParsed.pathname.toLowerCase() + urlParsed.search + urlParsed.hash;
   }
   next();
 }

--- a/cloud-function/src/middlewares/lowercase-pathname.js
+++ b/cloud-function/src/middlewares/lowercase-pathname.js
@@ -12,7 +12,6 @@ export async function lowercasePathname(req, _res, next) {
   if (urlParsed.pathname) {
     urlParsed.pathname = urlParsed.pathname.toLowerCase();
     req.url = urlParsed.pathname + urlParsed.search + urlParsed.hash;
-    req.originalUrl = req.url;
   }
   next();
 }

--- a/cloud-function/src/middlewares/lowercase-pathname.js
+++ b/cloud-function/src/middlewares/lowercase-pathname.js
@@ -2,7 +2,6 @@
 
 /**
  * Middleware that lowercases the pathname of the request URL.
- * Also updates originalUrl to support http-proxy-middleware v2.
  * @param {Request} req - Express request
  * @param {Response} _res - Express response
  * @param {NextFunction} next - Express next function
@@ -12,9 +11,7 @@ export async function lowercasePathname(req, _res, next) {
   const urlParsed = new URL(req.url, `${req.protocol}://${req.headers.host}`);
   if (urlParsed.pathname) {
     urlParsed.pathname = urlParsed.pathname.toLowerCase();
-    req.url = urlParsed.toString();
-    // Workaround for http-proxy-middleware v2 using `req.originalUrl`.
-    // See: https://github.com/chimurai/http-proxy-middleware/pull/731
+    req.url = urlParsed.pathname + urlParsed.search + urlParsed.hash;
     req.originalUrl = req.url;
   }
   next();

--- a/cloud-function/src/middlewares/lowercase-pathname.js
+++ b/cloud-function/src/middlewares/lowercase-pathname.js
@@ -8,10 +8,9 @@
  * @returns {Promise<void>}
  */
 export async function lowercasePathname(req, _res, next) {
-  const urlParsed = new URL(req.url, `${req.protocol}://${req.headers.host}`);
-  if (urlParsed.pathname) {
-    req.url =
-      urlParsed.pathname.toLowerCase() + urlParsed.search + urlParsed.hash;
+  const url = new URL(req.url, `${req.protocol}://${req.headers.host}`);
+  if (url.pathname) {
+    req.url = url.pathname.toLowerCase() + url.search + url.hash;
   }
   next();
 }

--- a/cloud-function/src/middlewares/lowercase-pathname.test.js
+++ b/cloud-function/src/middlewares/lowercase-pathname.test.js
@@ -1,0 +1,65 @@
+import { describe, it } from "node:test";
+import { strictEqual } from "node:assert/strict";
+import { createRequest, createResponse } from "node-mocks-http";
+
+import { lowercasePathname } from "./lowercase-pathname.js";
+
+/** @param {string} url */
+async function run(url) {
+  const req = createRequest({
+    method: "GET",
+    url,
+    protocol: "https",
+    hostname: "developer.mozilla.org",
+    headers: { host: "developer.mozilla.org" },
+  });
+  const res = createResponse();
+  let nextCalled = false;
+  await lowercasePathname(req, res, () => {
+    nextCalled = true;
+  });
+  return { req, nextCalled };
+}
+
+describe("lowercasePathname", () => {
+  /** @type {Array<[label: string, url: string, expected: string]>} */
+  const cases = [
+    [
+      "lowercases the pathname and keeps req.url path-relative",
+      "/EN-US/search-index.json",
+      "/en-us/search-index.json",
+    ],
+    [
+      "leaves an already-lowercase pathname unchanged",
+      "/en-us/search-index.json",
+      "/en-us/search-index.json",
+    ],
+    [
+      "preserves the query string",
+      "/EN-US/search-index.json?Foo=Bar",
+      "/en-us/search-index.json?Foo=Bar",
+    ],
+    [
+      "preserves the fragment",
+      "/EN-US/docs/Web/API#Section",
+      "/en-us/docs/web/api#Section",
+    ],
+    [
+      "preserves the query string and fragment together",
+      "/EN-US/docs/Web/API?Foo=Bar#Section",
+      "/en-us/docs/web/api?Foo=Bar#Section",
+    ],
+  ];
+
+  for (const [label, url, expected] of cases) {
+    it(`${label}: ${url} → ${expected}`, async () => {
+      const { req } = await run(url);
+      strictEqual(req.url, expected);
+    });
+  }
+
+  it("calls next()", async () => {
+    const { nextCalled } = await run("/EN-US/search-index.json");
+    strictEqual(nextCalled, true);
+  });
+});

--- a/cloud-function/src/middlewares/resolve-index-html.js
+++ b/cloud-function/src/middlewares/resolve-index-html.js
@@ -8,7 +8,6 @@ import { isAsset } from "../utils.js";
 /**
  * Middleware that resolves document URLs to index.html paths.
  * Converts URL slugs to folder paths and appends index.html for non-asset requests.
- * Also updates originalUrl to support http-proxy-middleware v2.
  * @param {Request} req - Express request
  * @param {Response} _res - Express response
  * @param {NextFunction} next - Express next function
@@ -22,9 +21,6 @@ export async function resolveIndexHTML(req, _res, next) {
       pathname = path.join(pathname, "index.html");
     }
     req.url = pathname; // e.g. "/en-us/docs/mozilla/add-ons/webextensions/browser_compatibility_for_manifest.json"
-    // Workaround for http-proxy-middleware v2 using `req.originalUrl`.
-    // See: https://github.com/chimurai/http-proxy-middleware/pull/731
-    req.originalUrl = req.url;
   }
   next();
 }


### PR DESCRIPTION
### Description

Make the `lowercasePathname` middleware assign a path-relative `req.url` so it stays correct under both `http-proxy-middleware` v3 and v4. Along the way:

- Drop the now-dead v2-only `req.originalUrl` workarounds in `lowercasePathname` and `resolveIndexHTML`.
- Add a regression test covering the path-relative rewrite.

### Motivation

The `http-proxy-middleware` v4 bump (#380) was reverted (#420) because v4 replaced its `http-proxy` engine with `httpxy`, which forwards `req.url` verbatim as the upstream path instead of extracting the path via `url.parse()`. Under v4, the absolute URL produced by `URL.prototype.toString()` leaked the scheme and host into the proxied path, so `search-index.json` requests 404'd (#419):

```
/content-prod-mdn/fred/http://developer.mozilla.org/en-us/search-index.json
```

Under v3 this doesn't reproduce, so the revert already restored correct behavior on `main`. Assigning a path-relative `req.url` (matching `resolveIndexHTML`) makes the middleware forward-compatible, so `http-proxy-middleware` can be re-bumped to v4 without reintroducing the regression.

### Additional details

`req.url` is now built directly from `pathname` + `search` + `hash`, which is correct under both engines. The `req.originalUrl` assignments were a v2-only workaround that no longer applies and are removed.

Forward-compatibility was verified by installing `http-proxy-middleware` v4.2.0 on top of this branch (the `package.json`/`package-lock.json` from mdn/dex@3fe82369808a8a166a969db6cfaecbd4e674420f, the tip of `dependabot/npm_and_yarn/cloud-function/http-proxy-middleware-4.2.0`): the full cloud-function test suite passes, including the `search-index.json` route.

### Related issues and pull requests

Related to #419. Unblocks a future re-bump of `http-proxy-middleware` to v4 (previously #380, reverted in #420).


