### PR TITLE
test(cloud-function): cover proxied content and shared-assets routes end-to-end

### DIFF
--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -106,6 +106,12 @@ const BUCKET_FILES = {
     body: "<h1>Introuvable</h1>",
     contentType: "text/html",
   },
+  // A 404 page for a locale that no other test touches, so its
+  // module-level cache entry starts cold — see the caching test below.
+  "de/404/index.html": {
+    body: "<h1>Nicht gefunden</h1>",
+    contentType: "text/html",
+  },
 };
 
 describe("proxied content routes", () => {
@@ -297,6 +303,28 @@ describe("proxied content routes", () => {
         );
       });
     }
+
+    it("caches the 404 page after the first fetch", async () => {
+      // Uses the dedicated `de` locale so its cache entry starts cold and this
+      // test is independent of the order the suites above run in.
+      const first = await handler.request("/de/docs/Web/Missing");
+      strictEqual(first.status, 404);
+      strictEqual(first.text, BUCKET_FILES["de/404/index.html"]?.body);
+      strictEqual(
+        bucket.requests.filter((path) => path === "de/404/index.html").length,
+        1,
+        `expected one de 404 fetch, got ${JSON.stringify(bucket.requests)}`
+      );
+
+      bucket.requests.length = 0;
+      const second = await handler.request("/de/docs/Web/Other");
+      strictEqual(second.status, 404);
+      strictEqual(second.text, BUCKET_FILES["de/404/index.html"]?.body);
+      ok(
+        !bucket.requests.includes("de/404/index.html"),
+        `expected the de 404 page to be served from cache, got ${JSON.stringify(bucket.requests)}`
+      );
+    });
 
     it("falls back to the en-US asset for a missing non-English attachment", async () => {
       const response = await handler.request("/fr/docs/Web/API/foo.png");

--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -263,6 +263,13 @@ describe("proxied content routes", () => {
   });
 
   describe("fallbacks", () => {
+    // `get404ForLocale` populates a module-level `notFoundBufferCache` on the
+    // first successful 404-page fetch (REVIEW_ROUTING is off here), so a
+    // locale's `404/index.html` is fetched from the bucket only once per
+    // process. The `bucket.requests` assertions below therefore rely on no
+    // earlier test having fetched that same 404 page first; keep 404-page
+    // cases here and mind the ordering if adding more.
+    //
     // Both locales are checked so an implementation that always returns the
     // en-US 404 page would fail the fr case.
     for (const [locale, folder] of [

--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -128,112 +128,104 @@ describe("proxied content routes", () => {
     bucket.requests.length = 0;
   });
 
-  describe("URL → bucket path mapping", () => {
-    /** @type {Array<[label: string, requestPath: string, bucketPath: string]>} */
-    const cases = [
-      [
-        "search index (lowercases locale)",
-        "/en-US/search-index.json",
-        "en-us/search-index.json",
-      ],
-      [
-        "locale metadata (.json slug, verbatim)",
-        "/en-US/metadata.json",
-        "en-us/metadata.json",
-      ],
-      [
-        "docs page (slug→folder + index.html)",
-        "/en-US/docs/Web/API",
-        "en-us/docs/web/api/index.html",
-      ],
-      [
-        "docs data (index.json, no index.html appended)",
-        "/en-US/docs/Web/API/index.json",
-        "en-us/docs/web/api/index.json",
-      ],
-      [
-        "docs metadata (metadata.json)",
-        "/en-US/docs/Web/API/metadata.json",
-        "en-us/docs/web/api/metadata.json",
-      ],
-      [
-        "docs contributors (contributors.txt)",
-        "/en-US/docs/Web/API/contributors.txt",
-        "en-us/docs/web/api/contributors.txt",
-      ],
-      [
-        "data file under a .json-suffixed slug",
-        "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/index.json",
-        "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.json",
-      ],
-      [
-        "slug with colon (:has → _colon_has)",
-        "/en-US/docs/Web/CSS/Reference/Selectors/:has",
-        "en-us/docs/web/css/reference/selectors/_colon_has/index.html",
-      ],
-      [
-        "data file under a colon slug",
-        "/en-US/docs/Web/CSS/Reference/Selectors/:has/index.json",
-        "en-us/docs/web/css/reference/selectors/_colon_has/index.json",
-      ],
-      [
-        "blog page",
-        "/en-US/blog/some-post/",
-        "en-us/blog/some-post/index.html",
-      ],
-      [
-        "curriculum landing",
-        "/en-US/curriculum/",
-        "en-us/curriculum/index.html",
-      ],
-      [
-        "static hashed JS bundle (verbatim)",
-        "/static/client/1002.41b70a0dadf2f657.js",
-        "static/client/1002.41b70a0dadf2f657.js",
-      ],
-      [
-        "static JS source map (verbatim)",
-        "/static/client/1002.41b70a0dadf2f657.js.map",
-        "static/client/1002.41b70a0dadf2f657.js.map",
-      ],
-      [
-        "static hashed CSS (verbatim)",
-        "/static/css/main.fe619051.css",
-        "static/css/main.fe619051.css",
-      ],
-      [
-        "static CSS source map (verbatim)",
-        "/static/css/main.fe619051.css.map",
-        "static/css/main.fe619051.css.map",
-      ],
-      [
-        "service worker (verbatim)",
-        "/static/service-worker/service-worker.js",
-        "static/service-worker/service-worker.js",
-      ],
-      [
-        "service worker source map (verbatim)",
-        "/static/service-worker/service-worker.js.map",
-        "static/service-worker/service-worker.js.map",
-      ],
-      [
-        "app asset (verbatim)",
-        "/assets/playground.png",
-        "assets/playground.png",
-      ],
-      [
-        "sitemap (verbatim)",
-        "/sitemaps/en-us/sitemap.xml.gz",
-        "sitemaps/en-us/sitemap.xml.gz",
-      ],
-      ["root file", "/favicon.ico", "favicon.ico"],
-      [
-        "doc attachment (slug→folder)",
-        "/en-US/docs/Web/API/foo.png",
-        "en-us/docs/web/api/foo.png",
-      ],
-    ];
+  /**
+   * Each entry drives both the URL→bucket-path mapping and the response-body
+   * passthrough suites below.
+   * @type {Array<[label: string, requestPath: string, bucketPath: string]>}
+   */
+  const cases = [
+    [
+      "search index (lowercases locale)",
+      "/en-US/search-index.json",
+      "en-us/search-index.json",
+    ],
+    [
+      "locale metadata (.json slug, verbatim)",
+      "/en-US/metadata.json",
+      "en-us/metadata.json",
+    ],
+    [
+      "docs page (slug→folder + index.html)",
+      "/en-US/docs/Web/API",
+      "en-us/docs/web/api/index.html",
+    ],
+    [
+      "docs data (index.json, no index.html appended)",
+      "/en-US/docs/Web/API/index.json",
+      "en-us/docs/web/api/index.json",
+    ],
+    [
+      "docs metadata (metadata.json)",
+      "/en-US/docs/Web/API/metadata.json",
+      "en-us/docs/web/api/metadata.json",
+    ],
+    [
+      "docs contributors (contributors.txt)",
+      "/en-US/docs/Web/API/contributors.txt",
+      "en-us/docs/web/api/contributors.txt",
+    ],
+    [
+      "data file under a .json-suffixed slug",
+      "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/index.json",
+      "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.json",
+    ],
+    [
+      "slug with colon (:has → _colon_has)",
+      "/en-US/docs/Web/CSS/Reference/Selectors/:has",
+      "en-us/docs/web/css/reference/selectors/_colon_has/index.html",
+    ],
+    [
+      "data file under a colon slug",
+      "/en-US/docs/Web/CSS/Reference/Selectors/:has/index.json",
+      "en-us/docs/web/css/reference/selectors/_colon_has/index.json",
+    ],
+    ["blog page", "/en-US/blog/some-post/", "en-us/blog/some-post/index.html"],
+    ["curriculum landing", "/en-US/curriculum/", "en-us/curriculum/index.html"],
+    [
+      "static hashed JS bundle (verbatim)",
+      "/static/client/1002.41b70a0dadf2f657.js",
+      "static/client/1002.41b70a0dadf2f657.js",
+    ],
+    [
+      "static JS source map (verbatim)",
+      "/static/client/1002.41b70a0dadf2f657.js.map",
+      "static/client/1002.41b70a0dadf2f657.js.map",
+    ],
+    [
+      "static hashed CSS (verbatim)",
+      "/static/css/main.fe619051.css",
+      "static/css/main.fe619051.css",
+    ],
+    [
+      "static CSS source map (verbatim)",
+      "/static/css/main.fe619051.css.map",
+      "static/css/main.fe619051.css.map",
+    ],
+    [
+      "service worker (verbatim)",
+      "/static/service-worker/service-worker.js",
+      "static/service-worker/service-worker.js",
+    ],
+    [
+      "service worker source map (verbatim)",
+      "/static/service-worker/service-worker.js.map",
+      "static/service-worker/service-worker.js.map",
+    ],
+    ["app asset (verbatim)", "/assets/playground.png", "assets/playground.png"],
+    [
+      "sitemap (verbatim)",
+      "/sitemaps/en-us/sitemap.xml.gz",
+      "sitemaps/en-us/sitemap.xml.gz",
+    ],
+    ["root file", "/favicon.ico", "favicon.ico"],
+    [
+      "doc attachment (slug→folder)",
+      "/en-US/docs/Web/API/foo.png",
+      "en-us/docs/web/api/foo.png",
+    ],
+  ];
 
+  describe("URL → bucket path mapping", () => {
     for (const [label, requestPath, bucketPath] of cases) {
       it(`maps ${label}: ${requestPath} → ${bucketPath}`, async () => {
         const response = await handler.request(requestPath);
@@ -248,18 +240,25 @@ describe("proxied content routes", () => {
   });
 
   describe("response body passthrough", () => {
-    it("serves the search index body", async () => {
-      const response = await handler.request("/en-US/search-index.json");
-      strictEqual(response.text, BUCKET_FILES["en-us/search-index.json"]?.body);
-    });
+    for (const [label, requestPath, bucketPath] of cases) {
+      it(`serves the ${label} body: ${requestPath}`, async () => {
+        const response = await handler.request(requestPath);
 
-    it("serves the docs page body", async () => {
-      const response = await handler.request("/en-US/docs/Web/API");
-      strictEqual(
-        response.text,
-        BUCKET_FILES["en-us/docs/web/api/index.html"]?.body
-      );
-    });
+        strictEqual(response.status, 200, `expected 200 for ${requestPath}`);
+        // The sitemap is stored gzip-compressed and served with
+        // `Content-Encoding: gzip`, so `fetch` transparently decompresses it;
+        // compare against the original uncompressed payload rather than the
+        // stored buffer.
+        const expected = bucketPath.endsWith(".gz")
+          ? "<urlset></urlset>"
+          : BUCKET_FILES[bucketPath]?.body;
+        strictEqual(
+          response.text,
+          expected,
+          `unexpected body for ${requestPath}`
+        );
+      });
+    }
   });
 
   describe("fallbacks", () => {

--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -1,0 +1,383 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import { deepStrictEqual, ok, strictEqual } from "node:assert/strict";
+import { gzipSync } from "node:zlib";
+
+import { startDummyBucket, startHandler } from "./proxy-helpers.js";
+
+/**
+ * Minimal bucket contents covering one file per proxied route category. Keys are
+ * bucket paths without a leading slash, mirroring the layout in
+ * `content-prod-mdn/` (locale folders are lowercase).
+ * @type {Record<string, import("./proxy-helpers.js").BucketFile>}
+ */
+const BUCKET_FILES = {
+  "en-us/search-index.json": {
+    body: '{"search":"index"}',
+    contentType: "application/json",
+  },
+  "en-us/metadata.json": {
+    body: '{"locale":"en-US"}',
+    contentType: "application/json",
+  },
+  "en-us/docs/web/api/index.html": {
+    body: "<h1>Web API</h1>",
+    contentType: "text/html",
+  },
+  "en-us/docs/web/api/index.json": {
+    body: '{"doc":"data"}',
+    contentType: "application/json",
+  },
+  "en-us/docs/web/api/metadata.json": {
+    body: '{"meta":"data"}',
+    contentType: "application/json",
+  },
+  "en-us/docs/web/api/contributors.txt": {
+    body: "contributors",
+    contentType: "text/plain",
+  },
+  // A doc page whose slug ends in ".json" (e.g. the WebExtensions manifest.json
+  // page). The page itself lives in a folder; only the sidecar files are objects.
+  "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html": {
+    body: "<h1>manifest.json</h1>",
+    contentType: "text/html",
+  },
+  "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.json": {
+    body: '{"slug":"manifest.json"}',
+    contentType: "application/json",
+  },
+  // A doc slug containing ":" which slugToFolder rewrites to "_colon_".
+  "en-us/docs/web/css/reference/selectors/_colon_has/index.html": {
+    body: "<h1>:has</h1>",
+    contentType: "text/html",
+  },
+  "en-us/docs/web/css/reference/selectors/_colon_has/index.json": {
+    body: '{"slug":":has"}',
+    contentType: "application/json",
+  },
+  "en-us/blog/some-post/index.html": {
+    body: "<h1>Some post</h1>",
+    contentType: "text/html",
+  },
+  "en-us/curriculum/index.html": {
+    body: "<h1>Curriculum</h1>",
+    contentType: "text/html",
+  },
+  "static/client/1002.41b70a0dadf2f657.js": {
+    body: "console.log('bundle');",
+    contentType: "application/javascript",
+  },
+  "static/client/1002.41b70a0dadf2f657.js.map": {
+    body: '{"version":3,"file":"bundle.js"}',
+    contentType: "application/json",
+  },
+  "static/css/main.fe619051.css": {
+    body: ".main{}",
+    contentType: "text/css",
+  },
+  "static/css/main.fe619051.css.map": {
+    body: '{"version":3,"file":"main.css"}',
+    contentType: "application/json",
+  },
+  "static/service-worker/service-worker.js": {
+    body: "self.addEventListener('install', () => {});",
+    contentType: "application/javascript",
+  },
+  "static/service-worker/service-worker.js.map": {
+    body: '{"version":3,"file":"service-worker.js"}',
+    contentType: "application/json",
+  },
+  "assets/playground.png": { body: "playground-png", contentType: "image/png" },
+  "sitemaps/en-us/sitemap.xml.gz": {
+    // Served with `Content-Encoding: gzip` (see headers.js), so use a real
+    // gzip payload the client can transparently decompress.
+    body: gzipSync("<urlset></urlset>"),
+    contentType: "application/xml",
+  },
+  "favicon.ico": { body: "favicon", contentType: "image/x-icon" },
+  "en-us/docs/web/api/foo.png": {
+    body: "foo-png-en-us",
+    contentType: "image/png",
+  },
+  "en-us/404/index.html": {
+    body: "<h1>Not found</h1>",
+    contentType: "text/html",
+  },
+  "fr/404/index.html": {
+    body: "<h1>Introuvable</h1>",
+    contentType: "text/html",
+  },
+};
+
+describe("proxied content routes", () => {
+  /** @type {Awaited<ReturnType<typeof startDummyBucket>>} */
+  let bucket;
+  /** @type {Awaited<ReturnType<typeof startHandler>>} */
+  let handler;
+
+  before(async () => {
+    bucket = await startDummyBucket(BUCKET_FILES);
+    handler = await startHandler(bucket.url);
+  });
+
+  after(async () => {
+    await handler?.close();
+    await bucket?.close();
+  });
+
+  beforeEach(() => {
+    bucket.requests.length = 0;
+  });
+
+  describe("URL → bucket path mapping", () => {
+    /** @type {Array<[label: string, requestPath: string, bucketPath: string]>} */
+    const cases = [
+      [
+        "search index (lowercases locale)",
+        "/en-US/search-index.json",
+        "en-us/search-index.json",
+      ],
+      [
+        "locale metadata (.json slug, verbatim)",
+        "/en-US/metadata.json",
+        "en-us/metadata.json",
+      ],
+      [
+        "docs page (slug→folder + index.html)",
+        "/en-US/docs/Web/API",
+        "en-us/docs/web/api/index.html",
+      ],
+      [
+        "docs data (index.json, no index.html appended)",
+        "/en-US/docs/Web/API/index.json",
+        "en-us/docs/web/api/index.json",
+      ],
+      [
+        "docs metadata (metadata.json)",
+        "/en-US/docs/Web/API/metadata.json",
+        "en-us/docs/web/api/metadata.json",
+      ],
+      [
+        "docs contributors (contributors.txt)",
+        "/en-US/docs/Web/API/contributors.txt",
+        "en-us/docs/web/api/contributors.txt",
+      ],
+      [
+        "data file under a .json-suffixed slug",
+        "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/index.json",
+        "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.json",
+      ],
+      [
+        "slug with colon (:has → _colon_has)",
+        "/en-US/docs/Web/CSS/Reference/Selectors/:has",
+        "en-us/docs/web/css/reference/selectors/_colon_has/index.html",
+      ],
+      [
+        "data file under a colon slug",
+        "/en-US/docs/Web/CSS/Reference/Selectors/:has/index.json",
+        "en-us/docs/web/css/reference/selectors/_colon_has/index.json",
+      ],
+      [
+        "blog page",
+        "/en-US/blog/some-post/",
+        "en-us/blog/some-post/index.html",
+      ],
+      [
+        "curriculum landing",
+        "/en-US/curriculum/",
+        "en-us/curriculum/index.html",
+      ],
+      [
+        "static hashed JS bundle (verbatim)",
+        "/static/client/1002.41b70a0dadf2f657.js",
+        "static/client/1002.41b70a0dadf2f657.js",
+      ],
+      [
+        "static JS source map (verbatim)",
+        "/static/client/1002.41b70a0dadf2f657.js.map",
+        "static/client/1002.41b70a0dadf2f657.js.map",
+      ],
+      [
+        "static hashed CSS (verbatim)",
+        "/static/css/main.fe619051.css",
+        "static/css/main.fe619051.css",
+      ],
+      [
+        "static CSS source map (verbatim)",
+        "/static/css/main.fe619051.css.map",
+        "static/css/main.fe619051.css.map",
+      ],
+      [
+        "service worker (verbatim)",
+        "/static/service-worker/service-worker.js",
+        "static/service-worker/service-worker.js",
+      ],
+      [
+        "service worker source map (verbatim)",
+        "/static/service-worker/service-worker.js.map",
+        "static/service-worker/service-worker.js.map",
+      ],
+      [
+        "app asset (verbatim)",
+        "/assets/playground.png",
+        "assets/playground.png",
+      ],
+      [
+        "sitemap (verbatim)",
+        "/sitemaps/en-us/sitemap.xml.gz",
+        "sitemaps/en-us/sitemap.xml.gz",
+      ],
+      ["root file", "/favicon.ico", "favicon.ico"],
+      [
+        "doc attachment (slug→folder)",
+        "/en-US/docs/Web/API/foo.png",
+        "en-us/docs/web/api/foo.png",
+      ],
+    ];
+
+    for (const [label, requestPath, bucketPath] of cases) {
+      it(`maps ${label}: ${requestPath} → ${bucketPath}`, async () => {
+        const response = await handler.request(requestPath);
+
+        strictEqual(response.status, 200, `expected 200 for ${requestPath}`);
+        ok(
+          bucket.requests.includes(bucketPath),
+          `expected bucket to receive "${bucketPath}", got ${JSON.stringify(bucket.requests)}`
+        );
+      });
+    }
+  });
+
+  describe("response body passthrough", () => {
+    it("serves the search index body", async () => {
+      const response = await handler.request("/en-US/search-index.json");
+      strictEqual(response.text, BUCKET_FILES["en-us/search-index.json"]?.body);
+    });
+
+    it("serves the docs page body", async () => {
+      const response = await handler.request("/en-US/docs/Web/API");
+      strictEqual(
+        response.text,
+        BUCKET_FILES["en-us/docs/web/api/index.html"]?.body
+      );
+    });
+  });
+
+  describe("fallbacks", () => {
+    // Both locales are checked so an implementation that always returns the
+    // en-US 404 page would fail the fr case.
+    for (const [locale, folder] of [
+      ["en-US", "en-us"],
+      ["fr", "fr"],
+    ]) {
+      it(`serves the ${locale} 404 page for a missing ${locale} doc`, async () => {
+        const response = await handler.request(`/${locale}/docs/Web/Missing`);
+
+        strictEqual(response.status, 404);
+        strictEqual(
+          response.text,
+          BUCKET_FILES[`${folder}/404/index.html`]?.body
+        );
+        ok(
+          bucket.requests.includes(`${folder}/404/index.html`),
+          `expected ${folder} 404 fallback fetch, got ${JSON.stringify(bucket.requests)}`
+        );
+      });
+    }
+
+    it("falls back to the en-US asset for a missing non-English attachment", async () => {
+      const response = await handler.request("/fr/docs/Web/API/foo.png");
+
+      strictEqual(response.status, 200);
+      strictEqual(
+        response.text,
+        BUCKET_FILES["en-us/docs/web/api/foo.png"]?.body
+      );
+      deepStrictEqual(
+        [
+          bucket.requests.includes("fr/docs/web/api/foo.png"),
+          bucket.requests.includes("en-us/docs/web/api/foo.png"),
+        ],
+        [true, true],
+        `expected fr miss then en-us fallback, got ${JSON.stringify(bucket.requests)}`
+      );
+    });
+
+    it("resolves a .json-suffixed page slug via the index.html fallback", async () => {
+      // The slug ends in ".json", so `isAsset` is true and no `index.html` is
+      // appended; the verbatim object 404s, and the 404 handler then retries
+      // with `/index.html` appended, which succeeds.
+      const response = await handler.request(
+        "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json"
+      );
+
+      strictEqual(response.status, 200);
+      strictEqual(
+        response.text,
+        BUCKET_FILES[
+          "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html"
+        ]?.body
+      );
+      deepStrictEqual(
+        bucket.requests,
+        [
+          "en-us/docs/mozilla/add-ons/webextensions/manifest.json",
+          "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html",
+        ],
+        `expected verbatim miss then index.html retry, got ${JSON.stringify(bucket.requests)}`
+      );
+    });
+
+    it("passes the upstream 404 through for a missing live sample", async () => {
+      // Live-sample URLs skip the index.html/404-page fallback (isLiveSampleURL
+      // → return null), so the upstream 404 is served as-is.
+      const response = await handler.request(
+        "/en-US/docs/Web/foo/_sample_.zzz.html"
+      );
+
+      strictEqual(response.status, 404);
+      deepStrictEqual(bucket.requests, [
+        "en-us/docs/web/foo/_sample_.zzz.html",
+      ]);
+      ok(
+        !bucket.requests.includes("en-us/404/index.html"),
+        "live-sample 404 should not trigger the 404-page fallback"
+      );
+    });
+
+    it("returns the upstream 404 for an inactive-locale attachment", async () => {
+      // proxyContentAssets only attempts an en-US fallback for active locales;
+      // an unknown locale returns null, passing the upstream 404 through.
+      const response = await handler.request("/zz/docs/Web/API/foo.png");
+
+      strictEqual(response.status, 404);
+      deepStrictEqual(bucket.requests, ["zz/docs/web/api/foo.png"]);
+    });
+
+    it("returns 404 when neither the localized nor the en-US attachment exists", async () => {
+      const response = await handler.request("/fr/docs/Web/API/missing.png");
+
+      strictEqual(response.status, 404);
+      deepStrictEqual(
+        [
+          bucket.requests.includes("fr/docs/web/api/missing.png"),
+          bucket.requests.includes("en-us/docs/web/api/missing.png"),
+        ],
+        [true, true],
+        `expected fr miss then en-us miss, got ${JSON.stringify(bucket.requests)}`
+      );
+    });
+
+    it("does not fall back to en-US for a missing non-English data file", async () => {
+      // Data files (index.json/metadata.json/…) route through `proxyContent`,
+      // not `proxyContentAssets`, so — unlike media attachments — a missing
+      // localized file serves the localized 404 rather than the en-US file.
+      const response = await handler.request("/fr/docs/Web/API/index.json");
+
+      strictEqual(response.status, 404);
+      ok(
+        !bucket.requests.includes("en-us/docs/web/api/index.json"),
+        `expected no en-US data fallback, got ${JSON.stringify(bucket.requests)}`
+      );
+    });
+  });
+});

--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -347,16 +347,19 @@ describe("proxied content routes", () => {
     it("passes the upstream 404 through for a missing live sample", async () => {
       // Live-sample URLs skip the index.html/404-page fallback (isLiveSampleURL
       // → return null), so the upstream 404 is served as-is.
+      //
+      // Uses the `ja` locale — whose 404 page no other test fetches — so the
+      // no-fallback assertions catch a regression regardless of suite order: a
+      // fallback would fetch `ja/404/index.html` from the (cold) bucket rather
+      // than hitting a warm cache from an earlier en-US/fr 404 test.
       const response = await handler.request(
-        "/en-US/docs/Web/foo/_sample_.zzz.html"
+        "/ja/docs/Web/foo/_sample_.zzz.html"
       );
 
       strictEqual(response.status, 404);
-      deepStrictEqual(bucket.requests, [
-        "en-us/docs/web/foo/_sample_.zzz.html",
-      ]);
+      deepStrictEqual(bucket.requests, ["ja/docs/web/foo/_sample_.zzz.html"]);
       ok(
-        !bucket.requests.includes("en-us/404/index.html"),
+        !bucket.requests.includes("ja/404/index.html"),
         "live-sample 404 should not trigger the 404-page fallback"
       );
     });

--- a/cloud-function/src/proxy-content.test.js
+++ b/cloud-function/src/proxy-content.test.js
@@ -165,6 +165,14 @@ describe("proxied content routes", () => {
       "en-us/docs/web/api/contributors.txt",
     ],
     [
+      // The slug ends in ".json", so no index.html is appended and the verbatim
+      // object 404s; the 404 handler then retries with "/index.html" appended,
+      // which succeeds.
+      "page slug ending in .json (resolves via index.html fallback)",
+      "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json",
+      "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html",
+    ],
+    [
       "data file under a .json-suffixed slug",
       "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/index.json",
       "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.json",
@@ -305,31 +313,6 @@ describe("proxied content routes", () => {
         ],
         [true, true],
         `expected fr miss then en-us fallback, got ${JSON.stringify(bucket.requests)}`
-      );
-    });
-
-    it("resolves a .json-suffixed page slug via the index.html fallback", async () => {
-      // The slug ends in ".json", so `isAsset` is true and no `index.html` is
-      // appended; the verbatim object 404s, and the 404 handler then retries
-      // with `/index.html` appended, which succeeds.
-      const response = await handler.request(
-        "/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json"
-      );
-
-      strictEqual(response.status, 200);
-      strictEqual(
-        response.text,
-        BUCKET_FILES[
-          "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html"
-        ]?.body
-      );
-      deepStrictEqual(
-        bucket.requests,
-        [
-          "en-us/docs/mozilla/add-ons/webextensions/manifest.json",
-          "en-us/docs/mozilla/add-ons/webextensions/manifest.json/index.html",
-        ],
-        `expected verbatim miss then index.html retry, got ${JSON.stringify(bucket.requests)}`
       );
     });
 

--- a/cloud-function/src/proxy-helpers.js
+++ b/cloud-function/src/proxy-helpers.js
@@ -1,0 +1,144 @@
+/** @import { AddressInfo } from "node:net" */
+/** @import { Server } from "node:http" */
+
+import { createServer } from "node:http";
+
+import express from "express";
+
+/** @param {string} name */
+const fixture = (name) => new URL(`fixtures/${name}`, import.meta.url).pathname;
+
+/**
+ * A single file served by the dummy bucket.
+ * @typedef {object} BucketFile
+ * @property {string | Buffer} body
+ * @property {string} [contentType]
+ */
+
+/**
+ * An in-memory stand-in for the content bucket.
+ * @typedef {object} DummyBucket
+ * @property {number} port
+ * @property {string} url - trailing-slashed base URL, e.g. "http://127.0.0.1:1234/"
+ * @property {string[]} requests - normalized paths (no leading slash) received, in order
+ * @property {() => Promise<void>} close
+ */
+
+/**
+ * Start an in-memory upstream that mimics the content bucket. It records every
+ * requested path (so tests can assert URL→file mapping) and serves the provided
+ * files, returning 404 for anything else.
+ * @param {Record<string, BucketFile>} files - keyed by bucket path without a
+ *   leading slash, e.g. "en-us/search-index.json"
+ * @returns {Promise<DummyBucket>}
+ */
+export async function startDummyBucket(files) {
+  /** @type {string[]} */
+  const requests = [];
+
+  const server = createServer((req, res) => {
+    const rawPath = (req.url ?? "/").split("?")[0] ?? "/";
+    const path = decodeURIComponent(rawPath).replace(/^\/+/, "");
+    requests.push(path);
+
+    const file = files[path];
+    if (!file) {
+      res.statusCode = 404;
+      res.setHeader("Content-Type", "text/plain");
+      res.end("not found");
+      return;
+    }
+
+    res.statusCode = 200;
+    res.setHeader(
+      "Content-Type",
+      file.contentType ?? "application/octet-stream"
+    );
+    res.end(file.body);
+  });
+
+  await listen(server);
+  const { port } = /** @type {AddressInfo} */ (server.address());
+
+  return {
+    port,
+    url: `http://127.0.0.1:${port}/`,
+    requests,
+    close: () => close(server),
+  };
+}
+
+/**
+ * A running instance of the MDN handler.
+ * @typedef {object} Handler
+ * @property {number} port
+ * @property {(path: string, init?: RequestInit) => Promise<{status: number, headers: Headers, text: string}>} request
+ * @property {() => Promise<void>} close
+ */
+
+/**
+ * Start the real MDN handler wired to the given upstream. `SOURCE_CONTENT` and
+ * the origins are captured at import time, so this must be called after the
+ * dummy bucket is listening and only once per test process.
+ * @param {string} sourceContent - trailing-slashed upstream URL (the dummy bucket)
+ * @returns {Promise<Handler>}
+ */
+export async function startHandler(sourceContent) {
+  // Prevent .env from overriding our test configuration.
+  process.env["ENV_FILE"] = "/dev/null";
+  process.env["SOURCE_CONTENT"] = sourceContent;
+  // Make the origin guards accept requests we send to 127.0.0.1.
+  process.env["ORIGIN_MAIN"] = "127.0.0.1";
+  process.env["ORIGIN_LIVE_SAMPLES"] = "127.0.0.1";
+  process.env["ORIGIN_PLAY"] = "127.0.0.1";
+  process.env["CANONICALS_FILE"] = fixture("canonicals.json");
+  process.env["REDIRECTS_FILE"] = fixture("redirects.json");
+
+  // Import after the env is set, since env.js and the proxy handlers capture
+  // SOURCE_CONTENT / the origins at module-load time.
+  const { createHandler } = await import("./app.js");
+  // Wrap in an Express app so req/res get the Express augmentation the handler
+  // relies on (req.hostname, res.sendStatus, …), just like the Functions
+  // Framework does in production.
+  const app = express();
+  app.use(createHandler());
+  const server = createServer(app);
+  await listen(server);
+  const { port } = /** @type {AddressInfo} */ (server.address());
+
+  return {
+    port,
+    request: async (path, init) => {
+      const response = await fetch(`http://127.0.0.1:${port}${path}`, {
+        redirect: "manual",
+        ...init,
+      });
+      return {
+        status: response.status,
+        headers: response.headers,
+        text: await response.text(),
+      };
+    },
+    close: () => close(server),
+  };
+}
+
+/**
+ * @param {Server} server
+ * @returns {Promise<void>}
+ */
+function listen(server) {
+  return new Promise((resolve) =>
+    server.listen(0, "127.0.0.1", () => resolve())
+  );
+}
+
+/**
+ * @param {Server} server
+ * @returns {Promise<void>}
+ */
+function close(server) {
+  return new Promise((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+}

--- a/cloud-function/src/proxy-helpers.js
+++ b/cloud-function/src/proxy-helpers.js
@@ -112,6 +112,14 @@ export async function startHandler(sourceContent, options = {}) {
   // Wrap in an Express app so req/res get the Express augmentation the handler
   // relies on (req.hostname, res.sendStatus, …), just like the Functions
   // Framework does in production.
+  //
+  // We deliberately don't use the Framework's own `getTestServer` helper: it
+  // hard-codes `ignoredRoutes: null`, which re-enables the default
+  // `/favicon.ico` and `/robots.txt` → 404 short-circuit. Production disables
+  // that via `functions-framework --ignored-routes ""`, so those paths reach
+  // the router and get proxied to the bucket (see the favicon test). Going
+  // through `getTestServer` would 404 them before the router runs.
+  // See https://github.com/GoogleCloudPlatform/functions-framework-nodejs/issues/778.
   const app = express();
   app.use(createHandler());
   const server = createServer(app);

--- a/cloud-function/src/proxy-helpers.js
+++ b/cloud-function/src/proxy-helpers.js
@@ -87,6 +87,12 @@ export async function startDummyBucket(files) {
  * @returns {Promise<Handler>}
  */
 export async function startHandler(sourceContent, options = {}) {
+  // These assignments mutate the process-wide `process.env` and are never
+  // restored, which is safe because `node --test` runs each test *file* in its
+  // own child process — so suites in separate files don't share this state. A
+  // second `startHandler` call in the same file would reuse the already-loaded
+  // (and env-captured) modules; call it once per process.
+  //
   // Prevent .env from overriding our test configuration.
   process.env["ENV_FILE"] = "/dev/null";
   process.env["SOURCE_CONTENT"] = sourceContent;

--- a/cloud-function/src/proxy-helpers.js
+++ b/cloud-function/src/proxy-helpers.js
@@ -77,16 +77,22 @@ export async function startDummyBucket(files) {
  */
 
 /**
- * Start the real MDN handler wired to the given upstream. `SOURCE_CONTENT` and
- * the origins are captured at import time, so this must be called after the
- * dummy bucket is listening and only once per test process.
+ * Start the real MDN handler wired to the given upstream. `SOURCE_CONTENT`, the
+ * shared-assets source, and the origins are captured at import time, so this
+ * must be called after the dummy bucket is listening and only once per test
+ * process.
  * @param {string} sourceContent - trailing-slashed upstream URL (the dummy bucket)
+ * @param {{ sourceSharedAssets?: string }} [options] - optional overrides;
+ *   `sourceSharedAssets` is the trailing-slashed shared-assets upstream URL
  * @returns {Promise<Handler>}
  */
-export async function startHandler(sourceContent) {
+export async function startHandler(sourceContent, options = {}) {
   // Prevent .env from overriding our test configuration.
   process.env["ENV_FILE"] = "/dev/null";
   process.env["SOURCE_CONTENT"] = sourceContent;
+  if (options.sourceSharedAssets) {
+    process.env["SOURCE_SHARED_ASSETS"] = options.sourceSharedAssets;
+  }
   // Make the origin guards accept requests we send to 127.0.0.1.
   process.env["ORIGIN_MAIN"] = "127.0.0.1";
   process.env["ORIGIN_LIVE_SAMPLES"] = "127.0.0.1";

--- a/cloud-function/src/proxy-shared-assets.test.js
+++ b/cloud-function/src/proxy-shared-assets.test.js
@@ -1,0 +1,90 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+
+import { startDummyBucket, startHandler } from "./proxy-helpers.js";
+
+const THIRTY_DAYS = 60 * 60 * 24 * 30;
+
+/**
+ * Files served by the dummy shared-assets upstream. Keys are upstream paths
+ * without a leading slash, i.e. after `/shared-assets/` has been stripped.
+ * @type {Record<string, import("./proxy-helpers.js").BucketFile>}
+ */
+const UPSTREAM_FILES = {
+  "audio/t-rex-roar.mp3": { body: "roar", contentType: "audio/mpeg" },
+  "fonts/Inter.var.woff2": { body: "font", contentType: "font/woff2" },
+  "images/examples/balloon.jpg": {
+    body: "balloon",
+    contentType: "image/jpeg",
+  },
+  "misc/friday.vtt": { body: "WEBVTT", contentType: "text/vtt" },
+  "text/quotes.md": { body: "# Quotes", contentType: "text/markdown" },
+  "videos/flower.webm": { body: "flower", contentType: "video/webm" },
+};
+
+describe("proxySharedAssets", () => {
+  /** @type {Awaited<ReturnType<typeof startDummyBucket>>} */
+  let upstream;
+  /** @type {Awaited<ReturnType<typeof startHandler>>} */
+  let handler;
+
+  before(async () => {
+    upstream = await startDummyBucket(UPSTREAM_FILES);
+    // `SOURCE_CONTENT` is irrelevant here; reuse the same upstream for it.
+    handler = await startHandler(upstream.url, {
+      sourceSharedAssets: upstream.url,
+    });
+  });
+
+  after(async () => {
+    await handler?.close();
+    await upstream?.close();
+  });
+
+  beforeEach(() => {
+    upstream.requests.length = 0;
+  });
+
+  describe("path rewrite", () => {
+    for (const upstreamPath of Object.keys(UPSTREAM_FILES)) {
+      it(`strips /shared-assets/ and passes the body through: ${upstreamPath}`, async () => {
+        const response = await handler.request(
+          `/shared-assets/${upstreamPath}`
+        );
+
+        strictEqual(response.status, 200);
+        deepStrictEqual(upstream.requests, [upstreamPath]);
+        strictEqual(response.text, UPSTREAM_FILES[upstreamPath]?.body);
+      });
+    }
+  });
+
+  describe("cache-control", () => {
+    it("sets a 30-day public cache on a 2xx response", async () => {
+      const response = await handler.request(
+        "/shared-assets/images/examples/balloon.jpg"
+      );
+
+      strictEqual(response.status, 200);
+      strictEqual(
+        response.headers.get("cache-control"),
+        `public, max-age=${THIRTY_DAYS}`
+      );
+    });
+
+    it("sets no-store on a non-2xx (missing) response", async () => {
+      const response = await handler.request(
+        "/shared-assets/images/examples/does-not-exist.jpg"
+      );
+
+      strictEqual(response.status, 404);
+      strictEqual(
+        response.headers.get("cache-control"),
+        "no-store, must-revalidate"
+      );
+      deepStrictEqual(upstream.requests, [
+        "images/examples/does-not-exist.jpg",
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
### Description

Add tests for the cloud function's proxied content routes. A new `node:test` suite stands up an in-memory bucket server and the real handler, then drives real HTTP requests to verify the URL→bucket-path mapping and fallback behavior:

- Route categories: search index, docs pages and their `index.json`/`metadata.json`/`contributors.txt` sidecars, locale `metadata.json`, blog, curriculum, static bundles + source maps, `assets`, sitemaps, root files and attachments (live-sample URLs are covered as a 404 passthrough below, since live samples no longer exist in the bucket).
- Slug edge cases: `.json`-suffixed page slugs (resolved via the `index.html` fallback), `:`→`_colon_` sanitization.
- Fallbacks: localized 404 page (asserted per-locale for `en-US` and `fr`), en-US asset fallback, live-sample/inactive-locale/exhausted-fallback 404 passthrough.
- Shared-assets proxy (`proxySharedAssets`): `/shared-assets/` prefix rewrite and body passthrough across the representative asset types (audio, fonts, images, misc, text, videos), plus the `Cache-Control` logic (30-day `public` cache on 2xx, `no-store, must-revalidate` on a non-2xx response).
- `proxy-helpers.js` provides `startDummyBucket` (records requested paths, serves minimal files) and `startHandler` (sets `SOURCE_CONTENT`/origins — and an optional `sourceSharedAssets` — before importing the handler and wraps `createHandler` in an Express app).

### Motivation

Ensure the core URL→file mapping and fallback logic of the content proxy, and the shared-assets proxy's rewrite/cache behavior, are exercised end-to-end. Previously no test reached the proxy/serve path, so path transforms (locale lowercasing, slug→folder, `index.html` resolution), the 404/en-US fallbacks, and the shared-assets rewrite/cache headers were untested.

### Additional details

Raises `cloud-function/src/handlers/proxy-content.js` line coverage from ~48% to ~91%. The remaining uncovered lines are the `REVIEW_ROUTING`-gated preview-deploy branches (which need a separate env-configured harness, and a raw `http` client to set the `Host` header), plus the 404-page locale fallback in `get404ForLocale` (an active locale whose `404/index.html` is missing falling back to the en-US 404 page, and the ultimate `"not found"` string when even that is absent), which is not `REVIEW_ROUTING`-gated and remains untested.

Run with `node --test cloud-function/src/proxy-content.test.js cloud-function/src/proxy-shared-assets.test.js` (or `npm run test` from the repo root).

### Related issues and pull requests

Related to https://github.com/mdn/dex/issues/419.
