### PR TITLE
fix(playground): guard runner against markup break-out

### DIFF
--- a/cloud-function/src/internal/play/index.js
+++ b/cloud-function/src/internal/play/index.js
@@ -90,6 +90,40 @@ function html(strings, ...args) {
 }
 
 /**
+ * Prevent user CSS from breaking out of the `<style>` element via a
+ * literal `</style` sequence. Inserting a backslash (`<\/style`) stops
+ * the HTML parser from ending the element while remaining equivalent
+ * inside CSS strings, where `\/` resolves to `/`.
+ * @param {string} css
+ */
+function escapeStyleText(css) {
+  return css.replace(/<\/(style)/gi, String.raw`<\/$1`);
+}
+
+/**
+ * Prevent user JS from breaking out of the `<script>` element via a
+ * literal `</script` sequence. Inserting a backslash (`<\/script`) stops
+ * the HTML parser from ending the element while remaining equivalent
+ * inside JS strings, template literals, and regexes, where `\/` resolves
+ * to `/`. The equivalence holds within literal *contents*; the
+ * pathological `x</script/` (a `<` operator immediately followed by a
+ * regex literal beginning with `script`, i.e. `x < /script/`) would not
+ * round-trip, but such code is vanishingly rare.
+ *
+ * Known limitation: this does not neutralize a `<!--` … `<script`
+ * sequence, which pushes the parser into the script-data-double-escaped
+ * state where the runner's own closing `</script>` no longer closes the
+ * element (swallowing everything after it, including the
+ * swallow-detection warning). No backslash escape fixes this without
+ * changing behavior (`<\!--` is an invalid escape in `/u` regexes), so
+ * such input still corrupts the runner.
+ * @param {string} js
+ */
+function escapeScriptText(js) {
+  return js.replace(/<\/(script)/gi, String.raw`<\/$1`);
+}
+
+/**
  * @param {State | null} state
  * @param {string} hrefWithCode
  * @param {string} searchWithState
@@ -434,7 +468,7 @@ export function renderHtml(state = null) {
             : ""
         }
         <style id="css-output">
-          ${css}
+          ${escapeStyleText(css)}
         </style>
         <script>
           const consoleProxy = new Proxy(console, {
@@ -532,7 +566,7 @@ export function renderHtml(state = null) {
           id="mdn-play-js"
           type="${defaults === "ix-wat" ? "module" : ""}"
         >
-          ${js};
+          ${escapeScriptText(js)};
         </script>
         <script>
           try {

--- a/cloud-function/src/internal/play/index.js
+++ b/cloud-function/src/internal/play/index.js
@@ -528,11 +528,26 @@ export function renderHtml(state = null) {
       </head>
       <body>
         ${htmlCode}
-        <script type="${defaults === "ix-wat" ? "module" : ""}">
+        <script
+          id="mdn-play-js"
+          type="${defaults === "ix-wat" ? "module" : ""}"
+        >
           ${js};
         </script>
         <script>
           try {
+            // Post-rendering check: an unclosed or malformed tag in the HTML input
+            // can swallow the following <script> element (its markup is parsed as
+            // attributes of the open tag), leaving the JavaScript source visible as
+            // text content. Detect that and warn the user.
+            const jsScript = document.querySelector("script#mdn-play-js");
+            if (!(jsScript instanceof HTMLScriptElement)) {
+              console.warn(
+                "[Playground] The JavaScript did not run because the HTML input " +
+                  'contains an unclosed or malformed tag (for example "<o"). ' +
+                  "Close the tag to run your code."
+              );
+            }
             window.parent.postMessage({ typ: "ready" }, "*");
           } catch (e) {
             console.error("[Playground] Failed to post ready message", e);


### PR DESCRIPTION
(⚠️ Mirrored from mdn/fred#1705. ⚠️ )

### Description

Update the mirrored Playground runner (`cloud-function/src/internal/play/index.js`) to guard the generated runner HTML against two markup break-out issues:

- Warn when malformed HTML swallows the JS `<script>`: add `id="mdn-play-js"` to the JS script element and check, in the following ready script, that it is still an `HTMLScriptElement`. An unclosed or malformed tag in the HTML input (for example `<o`) is parsed so the following `<script>` becomes attributes of the open tag, and the user's JS renders as visible text instead of running.
- Prevent CSS and JS from breaking out of their elements: escape literal `</style` and `</script` sequences by inserting a backslash (`<\/style`, `<\/script`) before interpolating `css` and `js`. The backslash stops the HTML parser from ending the element while remaining equivalent inside CSS/JS strings, where `\/` resolves to `/`.

### Motivation

Mirror mdn/fred#1705 into this repo's diverged copy of `libs/play/index.js`. This file is the deployed source that serves the Playground runner HTML in review and production environments, so this change is required for the fred fix to take effect there.

### Additional details

Verified with parse5: rendering `{ html: "annn <o jwj", ... }` yields an element carrying `id="mdn-play-js"` with tagName `o` (warning case), normal HTML yields a real `<script>`, and break-out payloads in `css` (`.a{content:"</style><script>alert(1)</script>"}`) and `js` (`console.log("</script><img src=x onerror=alert(1)>")`) inject zero `<script>`/`<img>` elements into the parsed tree.

### Related issues and pull requests

fix for mdn/fred#1440). Required for that fix to take effect in deployed/review environments.