### PR TITLE
fix(play): tag runner postMessages with uuid for isolation

### DIFF
--- a/cloud-function/src/internal/play/index.js
+++ b/cloud-function/src/internal/play/index.js
@@ -440,16 +440,19 @@ export function renderHtml(state = null) {
           const consoleProxy = new Proxy(console, {
             get(target, prop) {
               if (typeof target[prop] === "function") {
+                const uuid =
+                  new URLSearchParams(location.search).get("uuid") || undefined;
                 return (...args) => {
                   try {
                     window.parent.postMessage(
-                      { typ: "console", prop, args },
+                      { uuid, typ: "console", prop, args },
                       "*"
                     );
                   } catch {
                     try {
                       window.parent.postMessage(
                         {
+                          uuid,
                           typ: "console",
                           prop,
                           args: args.map((x) => {
@@ -466,6 +469,7 @@ export function renderHtml(state = null) {
                     } catch {
                       window.parent.postMessage(
                         {
+                          uuid,
                           typ: "console",
                           prop: "warn",
                           args: [
@@ -533,7 +537,9 @@ export function renderHtml(state = null) {
         </script>
         <script>
           try {
-            window.parent.postMessage({ typ: "ready" }, "*");
+            const uuid =
+              new URLSearchParams(location.search).get("uuid") || undefined;
+            window.parent.postMessage({ uuid, typ: "ready" }, "*");
           } catch (e) {
             console.error("[Playground] Failed to post ready message", e);
           }


### PR DESCRIPTION
### Description

Tag every message the mirrored Playground runner (`cloud-function/src/internal/play/index.js`) posts to its parent with a `uuid` read from the runner URL's `uuid` query param: the `console` proxy (all three `postMessage` branches) and the `ready` message now post `{ uuid, typ, ... }`. Matches fred's `vendor/yari/libs/play/index.js`, from which this file is vendored.

### Motivation

Let a parent hosting multiple runners filter incoming messages by `uuid` so runners can't cross-talk. This copy has never had it (`git log -S uuid` on the file is empty), unlike fred's.

### Additional details

Backward-compatible: the consumer is the parent frame (in fred, `components/play-runner/element.js`), not this repo. Its `_onMessage` falls back to deriving the uuid from the origin subdomain when a message omits `uuid`, so a parent that doesn't set the query param keeps working unchanged; one that sets it gets exact per-runner filtering.

### Related issues and pull requests

Part of #436.
Ports mdn/fred#150.