### PR TITLE
fix(search): breadcrumb url-like suggestions

### DIFF
--- a/cloud-function/src/handlers/handle-search-redirect.test.js
+++ b/cloud-function/src/handlers/handle-search-redirect.test.js
@@ -7,6 +7,7 @@ import { clearSearchIndexCache } from "../internal/quicksearch/index.js";
 import { BASE_URL_MAIN } from "../env.js";
 
 const INDEX = [
+  { title: "CSS box model", url: "/en-US/docs/Web/CSS/CSS_box_model" },
   {
     title: "Array.prototype.map()",
     url: "/en-US/docs/Web/JavaScript/Reference/Array/map",
@@ -19,10 +20,7 @@ const INDEX = [
 ];
 
 const FR_INDEX = [
-  {
-    title: "Array.prototype.map()",
-    url: "/fr/docs/Web/JavaScript/Reference/Array/map",
-  },
+  { title: "CSS box model", url: "/fr/docs/Web/CSS/CSS_box_model" },
 ];
 
 /**
@@ -56,7 +54,19 @@ describe("handleSearchRedirect", () => {
   });
 
   it("redirects an exact unique title match to its page", async () => {
-    const req = request("Array.prototype.map()");
+    const req = request("CSS box model");
+    const res = createResponse();
+    await handleSearchRedirect(req, res);
+
+    strictEqual(res.statusCode, 302);
+    strictEqual(
+      res._getRedirectUrl(),
+      `${BASE_URL_MAIN}/en-US/docs/Web/CSS/CSS_box_model`
+    );
+  });
+
+  it("redirects a url-like title with breadcrumbs to its page", async () => {
+    const req = request("Array.prototype.map() (JavaScript)");
     const res = createResponse();
     await handleSearchRedirect(req, res);
 
@@ -119,14 +129,16 @@ describe("handleSearchRedirect", () => {
   });
 
   it("redirects an exact match to the page in the locale query parameter", async () => {
-    const req = request("Array.prototype.map()", { query: { locale: "fr" } });
+    const req = request("CSS Box Model", {
+      query: { locale: "fr" },
+    });
     const res = createResponse();
     await handleSearchRedirect(req, res);
 
     strictEqual(res.statusCode, 302);
     strictEqual(
       res._getRedirectUrl(),
-      `${BASE_URL_MAIN}/fr/docs/Web/JavaScript/Reference/Array/map`
+      `${BASE_URL_MAIN}/fr/docs/Web/CSS/CSS_box_model`
     );
   });
 

--- a/cloud-function/src/handlers/handle-search-suggestions.test.js
+++ b/cloud-function/src/handlers/handle-search-suggestions.test.js
@@ -48,7 +48,7 @@ describe("handleSearchSuggestions", () => {
   });
 
   it("returns OpenSearch suggestions JSON for a query", async () => {
-    const req = request("array map");
+    const req = request("array");
     const res = createResponse();
     await handleSearchSuggestions(req, res);
 
@@ -58,8 +58,8 @@ describe("handleSearchSuggestions", () => {
       "application/x-suggestions+json; charset=utf-8"
     );
     deepStrictEqual(res._getJSONData(), [
-      "array map",
-      ["Array.prototype.map()"],
+      "array",
+      ["Array", "Array.prototype.map() (JavaScript)"],
     ]);
   });
 

--- a/cloud-function/src/internal/quicksearch/index.js
+++ b/cloud-function/src/internal/quicksearch/index.js
@@ -44,8 +44,6 @@ export function buildIndex(entries) {
     }
   });
 
-  // Enrich each entry with its display label: the bare title when unique, or
-  // `title (breadcrumb)` when several pages share a title.
   const items = entries.map((entry, i) => {
     const group = byTitle.get(entry.title) ?? [i];
     return { ...entry, label: generateLabel(entry, i, group, entries) };
@@ -132,8 +130,9 @@ function breadcrumbParts(url) {
  * @returns {string}
  */
 function generateLabel(entry, index, group, entries) {
-  // A title unique among all entries needs no breadcrumb to disambiguate it.
-  if (group.length <= 1) {
+  // Firefox drops "url-like" suggestions (bug 2061842)
+  const urlLike = !/\s/.test(entry.title) && /[/@:[.]/.test(entry.title);
+  if (group.length <= 1 && !urlLike) {
     return entry.title;
   }
   const parts = breadcrumbParts(entry.url);

--- a/cloud-function/src/internal/quicksearch/index.test.js
+++ b/cloud-function/src/internal/quicksearch/index.test.js
@@ -28,17 +28,24 @@ describe("splitQuery", () => {
 describe("buildIndex", () => {
   it("builds a flex index with lowercased title and slug tail", () => {
     const items = [
-      { title: "Array.prototype.map()", url: "/en-US/docs/Web/JS/map" },
-      { title: "Array", url: "/en-US/docs/Web/JS/Array" },
+      {
+        title: "Array.prototype.map()",
+        url: "/en-US/docs/Web/JavaScript/Reference/Array/map",
+      },
+      { title: "Array", url: "/en-US/docs/Web/JavaScript/Reference/Array" },
     ];
     const { flex, items: kept } = buildIndex(items);
     deepStrictEqual(kept, [
       {
         title: "Array.prototype.map()",
-        url: "/en-US/docs/Web/JS/map",
-        label: "Array.prototype.map()",
+        url: "/en-US/docs/Web/JavaScript/Reference/Array/map",
+        label: "Array.prototype.map() (JavaScript)",
       },
-      { title: "Array", url: "/en-US/docs/Web/JS/Array", label: "Array" },
+      {
+        title: "Array",
+        url: "/en-US/docs/Web/JavaScript/Reference/Array",
+        label: "Array",
+      },
     ]);
     deepStrictEqual(flex, [
       { index: 0, title: "array.prototype.map()", slugTail: "map" },
@@ -58,6 +65,44 @@ describe("buildIndex", () => {
     deepStrictEqual(
       items.map((item) => item.label),
       ["map()", "length (JavaScript)", "length (Web APIs)"]
+    );
+  });
+
+  it("leaves a unique title containing whitespace bare", () => {
+    const { items } = buildIndex([
+      {
+        title: "Array.prototype.map() method",
+        url: "/en-US/docs/Web/JavaScript/Reference/Array/map",
+      },
+    ]);
+    deepStrictEqual(
+      items.map((item) => item.label),
+      ["Array.prototype.map() method"]
+    );
+  });
+
+  it("breadcrumbs a unique single-word title that looks like a URL", () => {
+    const { items } = buildIndex([
+      { title: ":hover", url: "/en-US/docs/Web/CSS/:hover" },
+    ]);
+    deepStrictEqual(
+      items.map((item) => item.label),
+      [":hover (CSS)"]
+    );
+  });
+
+  it("leaves other unique single-word titles bare", () => {
+    const { items } = buildIndex([
+      { title: "map()", url: "/en-US/docs/Web/JavaScript/Reference/Array/map" },
+      {
+        title: "grid-template-columns",
+        url: "/en-US/docs/Web/CSS/grid-template-columns",
+      },
+      { title: "JavaScript", url: "/en-US/docs/Web/JavaScript" },
+    ]);
+    deepStrictEqual(
+      items.map((item) => item.label),
+      ["map()", "grid-template-columns", "JavaScript"]
     );
   });
 
@@ -108,7 +153,7 @@ describe("findExactMatch", () => {
     { title: "Overview", url: "/en-US/docs/Web/CSS/Overview/b" },
   ]);
 
-  it("matches a unique title case-insensitively", () => {
+  it("matches a unique label case-insensitively", () => {
     deepStrictEqual(
       findExactMatch("MAP()", index)?.url,
       "/en-US/docs/Web/JavaScript/Reference/Array/map"
@@ -167,7 +212,7 @@ describe("quickSearch", () => {
     const results = quickSearch("array map", index);
     deepStrictEqual(
       results.map((r) => r.label),
-      ["Array.prototype.map()"]
+      ["Array.prototype.map() (JavaScript)"]
     );
   });
 


### PR DESCRIPTION
Firefox drops suggestions with no spaces which look like a URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2061842

This works around that by appending a breadcrumb to these URL-like paths, so they now contain a space, and aren't filtered out.