### PR TITLE
fix(search): skip breadcrumbs which don't describe the page

### DIFF
--- a/cloud-function/src/internal/quicksearch/index.js
+++ b/cloud-function/src/internal/quicksearch/index.js
@@ -125,6 +125,26 @@ function breadcrumbParts(url) {
 }
 
 /**
+ * Separate from `breadcrumbParts` to keep that close to fred's implementation.
+ * @param {string} url
+ * @returns {string[]}
+ */
+function labelBreadcrumb(url) {
+  const parts = breadcrumbParts(url);
+  const skipSlugs = ["Mozilla/Add-ons", "Mozilla"];
+  for (const slug of skipSlugs) {
+    const skipParts = slug.split("/");
+    if (
+      parts.length > skipParts.length &&
+      skipParts.every((part, i) => part === parts[i])
+    ) {
+      return parts.slice(skipParts.length);
+    }
+  }
+  return parts;
+}
+
+/**
  * @param {SearchIndexEntry} entry
  * @param {number} index - `entry`'s own position in `entries`
  * @param {number[]} group - indices of all entries sharing `entry.title`
@@ -137,12 +157,12 @@ function generateLabel(entry, index, group, entries) {
   if (group.length <= 1 && !urlLike) {
     return entry.title;
   }
-  const parts = breadcrumbParts(entry.url);
+  const parts = labelBreadcrumb(entry.url);
   const others = group
     .filter((i) => i !== index)
     .map((i) => {
       const other = entries[i];
-      return other ? breadcrumbParts(other.url) : [];
+      return other ? labelBreadcrumb(other.url) : [];
     });
   // The shortest leading breadcrumb segments that set this entry apart from
   // every sibling, falling back to the full breadcrumb when one is identical.

--- a/cloud-function/src/internal/quicksearch/index.test.js
+++ b/cloud-function/src/internal/quicksearch/index.test.js
@@ -121,6 +121,31 @@ describe("buildIndex", () => {
     );
   });
 
+  it("skips leading breadcrumb segments that say nothing about the page", () => {
+    const { items } = buildIndex([
+      {
+        title: "foo.bar",
+        url: "/en-US/docs/Mozilla/Add-ons/WebExtensions/foobar",
+      },
+      { title: "foo.bar", url: "/en-US/docs/Mozilla/Add-ons/foobar" },
+      { title: "foo.bar", url: "/en-US/docs/Mozilla/Firefox/foobar" },
+      { title: "foo.bar", url: "/en-US/docs/Mozilla/foobar" },
+      { title: "foo.bar", url: "/en-US/docs/foo/Add-ons/foobar" },
+      { title: "foo.bar", url: "/en-US/docs/foo/Mozilla/foobar" },
+    ]);
+    deepStrictEqual(
+      items.map((item) => item.label),
+      [
+        "foo.bar (WebExtensions)",
+        "foo.bar (Add-ons)",
+        "foo.bar (Firefox)",
+        "foo.bar (Mozilla)",
+        "foo.bar (foo / Add-ons)",
+        "foo.bar (foo / Mozilla)",
+      ]
+    );
+  });
+
   it("extends the prefix only as far as needed to disambiguate", () => {
     const { items } = buildIndex([
       { title: "Iterators", url: "/en-US/docs/Web/JavaScript/Guide/Iterators" },


### PR DESCRIPTION
Ensures url-like titles under WebExtensions gets "url.like (WebExtensions)" as a suggestion rather than "url.like (Mozilla)"